### PR TITLE
feat: add daily F2/F3 schedule updater

### DIFF
--- a/.github/workflows/update-f2f3.yml
+++ b/.github/workflows/update-f2f3.yml
@@ -1,0 +1,31 @@
+name: Update F2/F3 schedule
+
+on:
+  schedule:
+    - cron: '0 0 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - name: Update schedule
+        run: node scripts/update-f2f3.js
+      - name: Commit changes
+        uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          commit_message: "chore: update F2/F3 schedule"
+          file_pattern: public/f2f3.json
+          commit_user_name: github-actions[bot]
+          commit_user_email: 41898282+github-actions[bot]@users.noreply.github.com

--- a/public/f2f3.json
+++ b/public/f2f3.json
@@ -1,10 +1,10 @@
 [
   {
     "series": "F2",
-    "round": "Sample Round",
-    "country": "Sampleland",
-    "circuit": "Sample Circuit",
-    "session": "Race",
-    "startsAtUtc": "2099-01-01T12:00:00Z"
+    "round": "Monza",
+    "country": "Italy",
+    "circuit": "Autodromo Nazionale Monza",
+    "session": "Qualifying",
+    "startsAtUtc": "2025-09-05T14:00:00Z"
   }
 ]

--- a/scripts/update-f2f3.js
+++ b/scripts/update-f2f3.js
@@ -1,0 +1,37 @@
+const fs = require('fs');
+
+async function fetchSeries(series) {
+  const year = new Date().getFullYear();
+  const url = `https://api.openf1.org/v1/schedule?series=${series}&year=${year}`;
+  try {
+    const res = await fetch(url);
+    if (!res.ok) {
+      console.error(`Failed to fetch ${series} schedule: ${res.status}`);
+      return [];
+    }
+    const data = await res.json();
+    return data.map(item => ({
+      series: series.toUpperCase(),
+      round: item.round ?? '',
+      country: item.country ?? '',
+      circuit: item.circuit_short_name ?? '',
+      session: item.session_name ?? '',
+      startsAtUtc: item.start_time ?? ''
+    }));
+  } catch (err) {
+    console.error(`Error fetching ${series} schedule`, err);
+    return [];
+  }
+}
+
+async function main() {
+  const f2 = await fetchSeries('f2');
+  const f3 = await fetchSeries('f3');
+  const combined = [...f2, ...f3];
+  fs.writeFileSync('public/f2f3.json', JSON.stringify(combined, null, 2) + '\n');
+}
+
+main().catch(err => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- add script to fetch F2/F3 schedule
- update daily workflow to commit schedule
- seed F2/F3 schedule file

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68c5fa2704988331b69dfb60841d65df