### PR TITLE
feat: apply F1-inspired dark theme

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -6,7 +6,22 @@ export const metadata = {
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="ru">
-      <body style={{fontFamily:'Inter, system-ui, Arial, sans-serif', background:'#fafafa'}}>
+      <head>
+        <link rel="preconnect" href="https://fonts.googleapis.com" />
+        <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="anonymous" />
+        <link
+          href="https://fonts.googleapis.com/css2?family=Titillium+Web:wght@400;600;700&display=swap"
+          rel="stylesheet"
+        />
+      </head>
+      <body
+        style={{
+          fontFamily: '"Titillium Web", system-ui, Arial, sans-serif',
+          background: '#000',
+          color: '#fff',
+          margin: 0,
+        }}
+      >
         {children}
       </body>
     </html>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -61,23 +61,64 @@ export default function Home() {
   }, [rows, includeF2F3, hours]);
 
   return (
-    <main style={{maxWidth: 980, margin: '32px auto', padding: '0 16px'}}>
-      <header style={{display:'flex', gap:12, alignItems:'center', justifyContent:'space-between', marginBottom: 16}}>
-        <h1 style={{fontSize: 'clamp(20px, 3vw, 28px)', margin:0}}>Ближайшие квалификации и гонки — F1 / F2 / F3</h1>
-        <a href="https://openf1.org" target="_blank" rel="noreferrer" style={{fontSize:12, opacity:.7}}>Источник F1: OpenF1</a>
+    <main style={{ maxWidth: 980, margin: '0 auto', padding: '32px 16px' }}>
+      <header
+        style={{
+          display: 'flex',
+          gap: 12,
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          marginBottom: 24,
+          background: '#e10600',
+          padding: 16,
+          borderRadius: 8,
+        }}
+      >
+        <h1
+          style={{
+            fontSize: 'clamp(20px, 3vw, 28px)',
+            margin: 0,
+            color: '#fff',
+          }}
+        >
+          Ближайшие квалификации и гонки — F1 / F2 / F3
+        </h1>
+        <a
+          href="https://openf1.org"
+          target="_blank"
+          rel="noreferrer"
+          style={{ fontSize: 12, opacity: 0.8, color: '#fff', textDecoration: 'none' }}
+        >
+          Источник F1: OpenF1
+        </a>
       </header>
 
-      <section style={{display:'flex', gap:16, alignItems:'center', flexWrap:'wrap', marginBottom:20}}>
-        <label style={{display:'inline-flex', gap:8, alignItems:'center'}}>
-          <input type="checkbox" checked={includeF2F3} onChange={e => setIncludeF2F3(e.target.checked)} />
+      <section
+        style={{
+          display: 'flex',
+          gap: 16,
+          alignItems: 'center',
+          flexWrap: 'wrap',
+          marginBottom: 20,
+        }}
+      >
+        <label style={{ display: 'inline-flex', gap: 8, alignItems: 'center' }}>
+          <input
+            type="checkbox"
+            checked={includeF2F3}
+            onChange={e => setIncludeF2F3(e.target.checked)}
+          />
           Показывать F2/F3 (если есть данные)
         </label>
-        <div style={{display:'inline-flex', gap:8, alignItems:'center'}}>
-          <span style={{fontSize:14, opacity:.8}}>Период:</span>
-          <select value={String(hours ?? '')} onChange={(e) => {
-            const v = e.target.value;
-            setHours(v ? Number(v) : undefined);
-          }}>
+        <div style={{ display: 'inline-flex', gap: 8, alignItems: 'center' }}>
+          <span style={{ fontSize: 14, opacity: 0.8 }}>Период:</span>
+          <select
+            value={String(hours ?? '')}
+            onChange={e => {
+              const v = e.target.value;
+              setHours(v ? Number(v) : undefined);
+            }}
+          >
             <option value="">30 дней</option>
             <option value="24">24 часа</option>
             <option value="48">48 часов</option>
@@ -85,28 +126,55 @@ export default function Home() {
             <option value="168">7 дней</option>
           </select>
         </div>
-        <div style={{fontSize:12, opacity:.7}}>Часовой пояс: <b>{BELGRADE_TZ}</b></div>
+        <div style={{ fontSize: 12, opacity: 0.7 }}>
+          Часовой пояс: <b>{BELGRADE_TZ}</b>
+        </div>
       </section>
 
-      <ul style={{display:'grid', gap:12, listStyle:'none', padding:0}}>
+      <ul style={{ display: 'grid', gap: 12, listStyle: 'none', padding: 0 }}>
         {filtered.map((r, i) => {
           const local = DateTime.fromISO(r.startsAtUtc, { zone: 'utc' }).setZone(BELGRADE_TZ);
           const utc = DateTime.fromISO(r.startsAtUtc, { zone: 'utc' });
           return (
-            <li key={i} style={{border:'1px solid #e5e5e5', borderRadius:12, padding:16, background:'#fff'}}>
-              <div style={{display:'flex', justifyContent:'space-between', alignItems:'center', marginBottom: 8}}>
-                <div style={{fontSize:12, opacity:.7}}>{r.series}</div>
-                <div style={{fontSize:12, opacity:.6}}>UTC: {utc.toFormat('dd LLL yyyy • HH:mm')}</div>
+            <li
+              key={i}
+              style={{
+                border: '1px solid #333',
+                borderRadius: 8,
+                padding: 16,
+                background: '#111',
+              }}
+            >
+              <div
+                style={{
+                  display: 'flex',
+                  justifyContent: 'space-between',
+                  alignItems: 'center',
+                  marginBottom: 8,
+                }}
+              >
+                <div style={{ fontSize: 12, opacity: 0.7 }}>{r.series}</div>
+                <div style={{ fontSize: 12, opacity: 0.6 }}>
+                  UTC: {utc.toFormat('dd LLL yyyy • HH:mm')}
+                </div>
               </div>
-              <div style={{fontSize:18, fontWeight:700}}>{r.round}{r.country ? ` • ${r.country}` : ''}</div>
-              <div style={{opacity:.8}}>{r.circuit ? r.circuit + ' • ' : ''}{r.session}</div>
-              <div style={{marginTop:6}}><b>{local.toFormat('ccc, dd LLL yyyy • HH:mm')}</b> ({BELGRADE_TZ})</div>
+              <div style={{ fontSize: 18, fontWeight: 700 }}>
+                {r.round}
+                {r.country ? ` • ${r.country}` : ''}
+              </div>
+              <div style={{ opacity: 0.8 }}>
+                {r.circuit ? r.circuit + ' • ' : ''}
+                {r.session}
+              </div>
+              <div style={{ marginTop: 6 }}>
+                <b>{local.toFormat('ccc, dd LLL yyyy • HH:mm')}</b> ({BELGRADE_TZ})
+              </div>
             </li>
           );
         })}
       </ul>
 
-      <footer style={{marginTop:24, fontSize:12, opacity:.7}}>
+      <footer style={{ marginTop: 24, fontSize: 12, opacity: 0.7 }}>
         F2/F3 данные читаются из <code>/f2f3.json</code> (обновляется вручную или через GitHub Actions).
       </footer>
     </main>


### PR DESCRIPTION
## Summary
- add F1-style fonts and dark palette
- restyle schedule layout with red header and dark cards

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c6030e7ad88331937b8b1bad175bc6