### PR TITLE
Remove schedule source info from site

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -277,9 +277,6 @@ export default function Home() {
         })}
       </ul>
 
-      <footer style={{ marginTop: 24, fontSize: 12, opacity: 0.7 }}>
-        Расписание читается из <code>/schedule.ics</code> (обновляется вручную или через GitHub Actions).
-      </footer>
     </main>
   );
 }


### PR DESCRIPTION
## Summary
- remove footer referencing schedule.ics source

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c70c2f8088833192a83b0e81107ffa