### PR TITLE
Refine typography and streamline controls

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -24,7 +24,9 @@ body {
     var(--bg-primary);
   background-color: var(--bg-primary);
   color: var(--text-primary);
-  font-family: 'Titillium Web', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  font-family: var(--font-sans), 'Manrope', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI',
+    sans-serif;
+  font-optical-sizing: auto;
   position: relative;
 }
 
@@ -186,8 +188,8 @@ button {
   z-index: 1;
   font-size: clamp(2rem, 4vw, 3rem);
   line-height: 1.1;
-  font-weight: 700;
-  letter-spacing: 0.02em;
+  font-weight: 800;
+  letter-spacing: 0.015em;
 }
 
 .hero__subtitle {
@@ -197,6 +199,24 @@ button {
   font-size: clamp(1rem, 2.4vw, 1.2rem);
   line-height: 1.6;
   color: var(--text-secondary);
+  font-weight: 500;
+}
+
+.hero__title,
+.hero__badge,
+.hero__stat-label,
+.hero__stat-value,
+.hero__stat-meta--highlight,
+.control-panel__label,
+.series-chip,
+.period-button,
+.timezone-chip,
+.event-card__series-pill,
+.event-card__datetime,
+.event-card__time,
+.event-card__title,
+.event-card__countdown {
+  font-family: var(--font-display), var(--font-sans), 'Manrope', sans-serif;
 }
 
 .hero__stats {
@@ -228,14 +248,14 @@ button {
 .hero__stat-label {
   font-size: 0.75rem;
   text-transform: uppercase;
-  letter-spacing: 0.14em;
+  letter-spacing: 0.12em;
   color: rgba(255, 255, 255, 0.62);
 }
 
 .hero__stat-value {
   font-size: clamp(1.1rem, 2.6vw, 1.6rem);
   font-weight: 700;
-  letter-spacing: 0.04em;
+  letter-spacing: 0.02em;
 }
 
 .hero__stat-meta {
@@ -276,12 +296,6 @@ button {
   font-weight: 700;
 }
 
-.control-panel__caption {
-  font-size: 0.82rem;
-  color: rgba(255, 255, 255, 0.55);
-  line-height: 1.4;
-}
-
 .series-chips,
 .period-buttons {
   display: flex;
@@ -299,8 +313,8 @@ button {
   border: 1px solid rgba(255, 255, 255, 0.12);
   background: rgba(14, 18, 30, 0.65);
   color: #ffffff;
-  font-weight: 600;
-  letter-spacing: 0.08em;
+  font-weight: 700;
+  letter-spacing: 0.1em;
   text-transform: uppercase;
   cursor: pointer;
   transition: transform 0.3s ease, border-color 0.3s ease, box-shadow 0.3s ease, background 0.3s ease;
@@ -347,8 +361,8 @@ button {
   border: 1px solid rgba(255, 255, 255, 0.12);
   background: rgba(14, 18, 30, 0.6);
   color: #ffffff;
-  font-weight: 600;
-  letter-spacing: 0.04em;
+  font-weight: 700;
+  letter-spacing: 0.08em;
   cursor: pointer;
   transition: transform 0.3s ease, border-color 0.3s ease, background 0.3s ease, box-shadow 0.3s ease;
 }
@@ -375,7 +389,7 @@ button {
   border: 1px solid rgba(255, 255, 255, 0.12);
   background: rgba(14, 18, 30, 0.6);
   font-weight: 600;
-  letter-spacing: 0.04em;
+  letter-spacing: 0.06em;
   color: #ffffff;
   box-shadow: 0 16px 34px -30px rgba(0, 0, 0, 0.8);
 }
@@ -481,7 +495,7 @@ button {
   align-items: flex-end;
   gap: 4px;
   text-transform: uppercase;
-  letter-spacing: 0.12em;
+  letter-spacing: 0.1em;
   color: rgba(255, 255, 255, 0.62);
   font-size: 0.78rem;
 }
@@ -489,7 +503,7 @@ button {
 .event-card__time {
   font-size: clamp(1.6rem, 3.4vw, 2rem);
   font-weight: 700;
-  letter-spacing: 0.18em;
+  letter-spacing: 0.12em;
   color: #ffffff;
 }
 
@@ -510,6 +524,7 @@ button {
   font-weight: 700;
   line-height: 1.35;
   color: #f7f8fc;
+  letter-spacing: 0.01em;
 }
 
 .event-card__country {
@@ -550,7 +565,7 @@ button {
   color: #ffffff;
   font-size: 0.9rem;
   font-weight: 600;
-  letter-spacing: 0.04em;
+  letter-spacing: 0.06em;
   box-shadow: 0 20px 50px -36px rgba(var(--accent-rgb), 0.9);
 }
 

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,4 +1,17 @@
 import './globals.css';
+import { Exo_2, Manrope } from 'next/font/google';
+
+const sans = Manrope({
+  subsets: ['latin', 'latin-ext', 'cyrillic'],
+  weight: ['400', '500', '600', '700'],
+  variable: '--font-sans',
+});
+
+const display = Exo_2({
+  subsets: ['latin', 'latin-ext', 'cyrillic'],
+  weight: ['500', '600', '700', '800'],
+  variable: '--font-display',
+});
 
 export const metadata = {
   title: 'F1/F2/F3 schedule',
@@ -8,15 +21,7 @@ export const metadata = {
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="ru">
-      <head>
-        <link rel="preconnect" href="https://fonts.googleapis.com" />
-        <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="anonymous" />
-        <link
-          href="https://fonts.googleapis.com/css2?family=Titillium+Web:wght@400;600;700&display=swap"
-          rel="stylesheet"
-        />
-      </head>
-      <body>{children}</body>
+      <body className={`${sans.variable} ${display.variable}`}>{children}</body>
     </html>
   );
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -123,9 +123,9 @@ function SeriesLogo({ series }: { series: Row['series'] }) {
           textAnchor="middle"
           dominantBaseline="middle"
           fill={accent}
-          fontFamily="'Arial Black', 'Segoe UI', sans-serif"
-          fontSize={14}
-          letterSpacing={1}
+          fontFamily="var(--font-display, 'Manrope')"
+          fontSize={15}
+          letterSpacing={1.2}
         >
           {series}
         </text>
@@ -309,9 +309,6 @@ export default function Home() {
               </label>
             ))}
           </div>
-          <span className="control-panel__caption">
-            Сочетайте разные формулы, чтобы поймать общий ритм гоночного уик-энда.
-          </span>
         </div>
 
         <div className="control-panel__group">
@@ -329,10 +326,6 @@ export default function Home() {
               </button>
             ))}
           </div>
-          <span className="control-panel__caption">
-            Окно прокручивается вместе с настоящим моментом — расширьте диапазон, чтобы увидеть
-            больше.
-          </span>
         </div>
 
         <div className="control-panel__group">
@@ -341,9 +334,6 @@ export default function Home() {
             <span className="timezone-chip__dot" aria-hidden />
             <span>{userTz}</span>
           </div>
-          <span className="control-panel__caption">
-            Все времена на карточках автоматически приведены к вашему устройству.
-          </span>
         </div>
       </section>
 


### PR DESCRIPTION
## Summary
- integrate Exo 2 and Manrope via `next/font` and apply the pairing across accent UI elements
- retune weights and letter spacing so badges, chips, and event cards align with the new typography
- remove the descriptive captions from the control panel to keep the toggles focused

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c87f0a12f88331964b4d174ba56a12