### PR TITLE
Combine hero and controls into single section

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -142,6 +142,22 @@ button {
   background: radial-gradient(circle at center, rgba(0, 144, 255, 0.22), transparent 75%);
 }
 
+.hero__grid {
+  position: relative;
+  z-index: 1;
+  display: grid;
+  gap: clamp(28px, 6vw, 42px);
+  grid-template-columns: minmax(0, 1.25fr) minmax(0, 1fr);
+  align-items: start;
+}
+
+.hero__intro {
+  display: flex;
+  flex-direction: column;
+  gap: clamp(18px, 3vw, 28px);
+  min-width: 0;
+}
+
 .hero__badge {
   position: relative;
   z-index: 1;
@@ -269,7 +285,9 @@ button {
   font-weight: 600;
 }
 
-.control-panel {
+.hero__controls {
+  position: relative;
+  z-index: 1;
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
   gap: clamp(18px, 4vw, 28px);
@@ -279,6 +297,8 @@ button {
   background: rgba(10, 14, 24, 0.72);
   box-shadow: var(--shadow-ambient);
   backdrop-filter: blur(18px);
+  min-width: 0;
+  align-self: stretch;
 }
 
 .control-panel__group {
@@ -584,6 +604,17 @@ button {
   outline-offset: 2px;
 }
 
+@media (max-width: 960px) {
+  .hero__grid {
+    grid-template-columns: 1fr;
+    gap: clamp(24px, 8vw, 36px);
+  }
+
+  .hero__controls {
+    grid-template-columns: 1fr;
+  }
+}
+
 @media (max-width: 900px) {
   .event-card__top {
     flex-direction: column;
@@ -607,7 +638,7 @@ button {
 }
 
 @media (max-width: 540px) {
-  .control-panel {
+  .hero__controls {
     grid-template-columns: 1fr;
   }
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -234,105 +234,108 @@ export default function Home() {
           } as CSSProperties
         }
       >
-        <span className="hero__badge">
-          <span className="hero__pulse" aria-hidden />
-          живой календарь уик-эндов
-        </span>
-        <h1 className="hero__title">Ближайшие квалификации и гонки — F1 / F2 / F3</h1>
-        <p className="hero__subtitle">
-          Синхронизируйтесь с динамикой гоночных уик-эндов: фильтруйте серии, управляйте
-          горизонтом просмотра и следите за временем старта в собственном часовом поясе.
-        </p>
-        <div className="hero__stats">
-          <div className="hero__stat">
-            <span className="hero__stat-label">Активные серии</span>
-            <span className="hero__stat-value">{activeSeriesLabel}</span>
-            <span className="hero__stat-meta">переключите ниже</span>
-          </div>
-          <div className="hero__stat hero__stat--accent">
-            <span className="hero__stat-label">Ближайший старт</span>
-            {nextEvent && nextLocal ? (
-              <>
-                <span className="hero__stat-value">{nextLocal.toFormat('dd LLL • HH:mm')}</span>
-                <span className="hero__stat-meta">
-                  {nextEvent.series} · {nextDescriptor}
-                </span>
-                {nextCountdown && (
-                  <span className="hero__stat-meta hero__stat-meta--highlight">
-                    {nextCountdown}
-                  </span>
+        <div className="hero__grid">
+          <div className="hero__intro">
+            <span className="hero__badge">
+              <span className="hero__pulse" aria-hidden />
+              живой календарь уик-эндов
+            </span>
+            <h1 className="hero__title">Ближайшие квалификации и гонки — F1 / F2 / F3</h1>
+            <p className="hero__subtitle">
+              Синхронизируйтесь с динамикой гоночных уик-эндов: фильтруйте серии, управляйте
+              горизонтом просмотра и следите за временем старта в собственном часовом поясе.
+            </p>
+            <div className="hero__stats">
+              <div className="hero__stat">
+                <span className="hero__stat-label">Активные серии</span>
+                <span className="hero__stat-value">{activeSeriesLabel}</span>
+                <span className="hero__stat-meta">переключите ниже</span>
+              </div>
+              <div className="hero__stat hero__stat--accent">
+                <span className="hero__stat-label">Ближайший старт</span>
+                {nextEvent && nextLocal ? (
+                  <>
+                    <span className="hero__stat-value">{nextLocal.toFormat('dd LLL • HH:mm')}</span>
+                    <span className="hero__stat-meta">
+                      {nextEvent.series} · {nextDescriptor}
+                    </span>
+                    {nextCountdown && (
+                      <span className="hero__stat-meta hero__stat-meta--highlight">
+                        {nextCountdown}
+                      </span>
+                    )}
+                  </>
+                ) : (
+                  <>
+                    <span className="hero__stat-value">Нет событий</span>
+                    <span className="hero__stat-meta">Попробуйте расширить период</span>
+                  </>
                 )}
-              </>
-            ) : (
-              <>
-                <span className="hero__stat-value">Нет событий</span>
-                <span className="hero__stat-meta">Попробуйте расширить период</span>
-              </>
-            )}
+              </div>
+              <div className="hero__stat">
+                <span className="hero__stat-label">Событий в окне</span>
+                <span className="hero__stat-value">{filtered.length}</span>
+                <span className="hero__stat-meta">{selectedPeriodLabel}</span>
+              </div>
+            </div>
           </div>
-          <div className="hero__stat">
-            <span className="hero__stat-label">Событий в окне</span>
-            <span className="hero__stat-value">{filtered.length}</span>
-            <span className="hero__stat-meta">{selectedPeriodLabel}</span>
-          </div>
-        </div>
-      </section>
+          <div className="hero__controls">
+            <div className="control-panel__group">
+              <span className="control-panel__label">Серии</span>
+              <div className="series-chips">
+                {(['F1', 'F2', 'F3'] as Row['series'][]).map(series => (
+                  <label
+                    key={series}
+                    className="series-chip"
+                    data-active={visibleSeries[series]}
+                    style={
+                      {
+                        '--chip-color': SERIES_COLORS[series],
+                        '--chip-rgb': SERIES_ACCENT_RGB[series],
+                      } as CSSProperties
+                    }
+                  >
+                    <input
+                      type="checkbox"
+                      checked={visibleSeries[series]}
+                      onChange={() =>
+                        setVisibleSeries(prev => ({
+                          ...prev,
+                          [series]: !prev[series],
+                        }))
+                      }
+                    />
+                    <span className="series-chip__indicator" aria-hidden />
+                    <span>{series}</span>
+                  </label>
+                ))}
+              </div>
+            </div>
 
-      <section className="control-panel">
-        <div className="control-panel__group">
-          <span className="control-panel__label">Серии</span>
-          <div className="series-chips">
-            {(['F1', 'F2', 'F3'] as Row['series'][]).map(series => (
-              <label
-                key={series}
-                className="series-chip"
-                data-active={visibleSeries[series]}
-                style={
-                  {
-                    '--chip-color': SERIES_COLORS[series],
-                    '--chip-rgb': SERIES_ACCENT_RGB[series],
-                  } as CSSProperties
-                }
-              >
-                <input
-                  type="checkbox"
-                  checked={visibleSeries[series]}
-                  onChange={() =>
-                    setVisibleSeries(prev => ({
-                      ...prev,
-                      [series]: !prev[series],
-                    }))
-                  }
-                />
-                <span className="series-chip__indicator" aria-hidden />
-                <span>{series}</span>
-              </label>
-            ))}
-          </div>
-        </div>
+            <div className="control-panel__group">
+              <span className="control-panel__label">Период обзора</span>
+              <div className="period-buttons">
+                {PERIOD_OPTIONS.map(opt => (
+                  <button
+                    key={opt.label}
+                    type="button"
+                    className="period-button"
+                    data-active={hours === opt.value}
+                    onClick={() => setHours(opt.value)}
+                  >
+                    {opt.label}
+                  </button>
+                ))}
+              </div>
+            </div>
 
-        <div className="control-panel__group">
-          <span className="control-panel__label">Период обзора</span>
-          <div className="period-buttons">
-            {PERIOD_OPTIONS.map(opt => (
-              <button
-                key={opt.label}
-                type="button"
-                className="period-button"
-                data-active={hours === opt.value}
-                onClick={() => setHours(opt.value)}
-              >
-                {opt.label}
-              </button>
-            ))}
-          </div>
-        </div>
-
-        <div className="control-panel__group">
-          <span className="control-panel__label">Часовой пояс</span>
-          <div className="timezone-chip">
-            <span className="timezone-chip__dot" aria-hidden />
-            <span>{userTz}</span>
+            <div className="control-panel__group">
+              <span className="control-panel__label">Часовой пояс</span>
+              <div className="timezone-chip">
+                <span className="timezone-chip__dot" aria-hidden />
+                <span>{userTz}</span>
+              </div>
+            </div>
           </div>
         </div>
       </section>


### PR DESCRIPTION
## Summary
- merge the hero and control panel into a single composite section on the landing page
- add supporting layout styles for the new hero grid and integrated control panel, including responsive tweaks

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c886859bb08331b5ff2c39f5ecda32