### PR TITLE
Fix series control panel color references

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -372,52 +372,21 @@ export default function Home() {
       </section>
 
       <section className="control-panel">
-        <div className="control-panel__group">
-          <span className="control-panel__label">Серии</span>
-          <div className="series-chips">
-            {SERIES_IDS.map(series => {
-              const definition = SERIES_DEFINITIONS[series];
-              return (
-                <label
-                  key={series}
-                  className="series-chip"
-                  data-active={visibleSeries[series]}
-                  style={
-                    {
-                      '--chip-color': definition.accentColor,
-                      '--chip-rgb': definition.accentRgb,
-                    } as CSSProperties
-                  }
-                >
-                  <input
-                    type="checkbox"
-                    checked={visibleSeries[series]}
-                    onChange={() =>
-                      setVisibleSeries(prev => ({
-                        ...prev,
-                        [series]: !prev[series],
-                      }))
-                    }
-                  />
-                  <span className="series-chip__indicator" aria-hidden />
-                  <span>{definition.label}</span>
-                </label>
-              );
-            })}
-          </div>
-          <div className="hero__controls">
-            <div className="control-panel__group">
-              <span className="control-panel__label">Серии</span>
-              <div className="series-chips">
-                {(['F1', 'F2', 'F3'] as Row['series'][]).map(series => (
+        <div className="hero__controls">
+          <div className="control-panel__group">
+            <span className="control-panel__label">Серии</span>
+            <div className="series-chips">
+              {SERIES_IDS.map(series => {
+                const definition = SERIES_DEFINITIONS[series];
+                return (
                   <label
                     key={series}
                     className="series-chip"
                     data-active={visibleSeries[series]}
                     style={
                       {
-                        '--chip-color': SERIES_COLORS[series],
-                        '--chip-rgb': SERIES_ACCENT_RGB[series],
+                        '--chip-color': definition.accentColor,
+                        '--chip-rgb': definition.accentRgb,
                       } as CSSProperties
                     }
                   >
@@ -432,35 +401,35 @@ export default function Home() {
                       }
                     />
                     <span className="series-chip__indicator" aria-hidden />
-                    <span>{series}</span>
+                    <span>{definition.label}</span>
                   </label>
-                ))}
-              </div>
+                );
+              })}
             </div>
+          </div>
 
-            <div className="control-panel__group">
-              <span className="control-panel__label">Период обзора</span>
-              <div className="period-buttons">
-                {PERIOD_OPTIONS.map(opt => (
-                  <button
-                    key={opt.label}
-                    type="button"
-                    className="period-button"
-                    data-active={hours === opt.value}
-                    onClick={() => setHours(opt.value)}
-                  >
-                    {opt.label}
-                  </button>
-                ))}
-              </div>
+          <div className="control-panel__group">
+            <span className="control-panel__label">Период обзора</span>
+            <div className="period-buttons">
+              {PERIOD_OPTIONS.map(opt => (
+                <button
+                  key={opt.label}
+                  type="button"
+                  className="period-button"
+                  data-active={hours === opt.value}
+                  onClick={() => setHours(opt.value)}
+                >
+                  {opt.label}
+                </button>
+              ))}
             </div>
+          </div>
 
-            <div className="control-panel__group">
-              <span className="control-panel__label">Часовой пояс</span>
-              <div className="timezone-chip">
-                <span className="timezone-chip__dot" aria-hidden />
-                <span>{userTz}</span>
-              </div>
+          <div className="control-panel__group">
+            <span className="control-panel__label">Часовой пояс</span>
+            <div className="timezone-chip">
+              <span className="timezone-chip__dot" aria-hidden />
+              <span>{userTz}</span>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- reorganize the control panel markup to reuse the shared series definitions
- remove the stale references to undefined color constants in the series chips
- keep the period and timezone controls within the unified hero controls container

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c893a387548331a7d312dc5ff7b769