### PR TITLE
Add favicon and fix series chip styling

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,3 +1,4 @@
+import type { Metadata } from 'next';
 import './globals.css';
 import { Exo_2, Manrope } from 'next/font/google';
 
@@ -13,9 +14,12 @@ const display = Exo_2({
   variable: '--font-display',
 });
 
-export const metadata = {
+export const metadata: Metadata = {
   title: 'F1/F2/F3 schedule',
   description: 'Upcoming qualifying & race times (your time zone)',
+  icons: {
+    icon: '/favicon.svg',
+  },
 };
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -409,32 +409,36 @@ export default function Home() {
             <div className="control-panel__group">
               <span className="control-panel__label">Серии</span>
               <div className="series-chips">
-                {(['F1', 'F2', 'F3'] as Row['series'][]).map(series => (
-                  <label
-                    key={series}
-                    className="series-chip"
-                    data-active={visibleSeries[series]}
-                    style={
-                      {
-                        '--chip-color': SERIES_COLORS[series],
-                        '--chip-rgb': SERIES_ACCENT_RGB[series],
-                      } as CSSProperties
-                    }
-                  >
-                    <input
-                      type="checkbox"
-                      checked={visibleSeries[series]}
-                      onChange={() =>
-                        setVisibleSeries(prev => ({
-                          ...prev,
-                          [series]: !prev[series],
-                        }))
+                {(['F1', 'F2', 'F3'] as Row['series'][]).map(series => {
+                  const definition = SERIES_DEFINITIONS[series];
+
+                  return (
+                    <label
+                      key={series}
+                      className="series-chip"
+                      data-active={visibleSeries[series]}
+                      style={
+                        {
+                          '--chip-color': definition.accentColor,
+                          '--chip-rgb': definition.accentRgb,
+                        } as CSSProperties
                       }
-                    />
-                    <span className="series-chip__indicator" aria-hidden />
-                    <span>{series}</span>
-                  </label>
-                ))}
+                    >
+                      <input
+                        type="checkbox"
+                        checked={visibleSeries[series]}
+                        onChange={() =>
+                          setVisibleSeries(prev => ({
+                            ...prev,
+                            [series]: !prev[series],
+                          }))
+                        }
+                      />
+                      <span className="series-chip__indicator" aria-hidden />
+                      <span>{definition.label}</span>
+                    </label>
+                  );
+                })}
               </div>
             </div>
 

--- a/public/favicon.svg
+++ b/public/favicon.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <rect width="64" height="64" rx="12" fill="#d32f2f"/>
+  <path fill="#ffffff" d="M15 20h10l-1.5 4h-6.6L15 20zm13 0h10l-1.5 4h-6.6L28 20zm-13 9h10l-1.5 4h-6.6L15 29zm13 0h10l-1.5 4h-6.6L28 29zm13-9h10l-1.5 4h-6.6L41 20zm0 9h10l-1.5 4h-6.6L41 29z"/>
+  <path fill="#ffffff" d="M18 43h28l-2 6H16l2-6z"/>
+</svg>


### PR DESCRIPTION
## Summary
- add a favicon reference in the root layout metadata so the tab displays an icon
- provide a racing-themed SVG favicon asset in the public folder
- fix the series filter chips to reuse the series definitions for their colors and labels

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c89410e4bc8331b417e20d32e2a990