### PR TITLE
feat: merge series filters into top menu

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -224,7 +224,7 @@ button {
 .hero__stat-value,
 .hero__stat-meta--highlight,
 .control-panel__label,
-.series-chip,
+.series-toggle,
 .period-button,
 .timezone-chip,
 .event-card__series-pill,
@@ -285,11 +285,11 @@ button {
   font-weight: 600;
 }
 
-.hero__controls {
+.top-menu {
   position: relative;
   z-index: 1;
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  grid-template-columns: minmax(0, 1.35fr) minmax(0, 1fr);
   gap: clamp(18px, 4vw, 28px);
   padding: clamp(22px, 4vw, 32px);
   border-radius: clamp(22px, 4vw, 30px);
@@ -298,7 +298,43 @@ button {
   box-shadow: var(--shadow-ambient);
   backdrop-filter: blur(18px);
   min-width: 0;
-  align-self: stretch;
+  align-items: start;
+}
+
+.top-menu__series {
+  display: flex;
+  flex-direction: column;
+  gap: clamp(14px, 3vw, 20px);
+  min-width: 0;
+}
+
+.top-menu__filters {
+  display: flex;
+  flex-direction: column;
+  gap: clamp(18px, 3vw, 24px);
+  min-width: 0;
+}
+
+.top-menu__series-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.top-menu__active-summary {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  color: rgba(255, 255, 255, 0.58);
+  font-weight: 600;
+}
+
+.top-menu__series-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 14px;
 }
 
 .control-panel__group {
@@ -316,25 +352,24 @@ button {
   font-weight: 700;
 }
 
-.series-chips,
 .period-buttons {
   display: flex;
   flex-wrap: wrap;
   gap: 12px;
 }
 
-.series-chip {
+.series-toggle {
   position: relative;
   display: inline-flex;
   align-items: center;
-  gap: 10px;
-  padding: 10px 16px;
-  border-radius: 999px;
+  gap: 14px;
+  padding: 12px 18px 12px 12px;
+  border-radius: 18px;
   border: 1px solid rgba(255, 255, 255, 0.12);
   background: rgba(14, 18, 30, 0.65);
   color: #ffffff;
   font-weight: 700;
-  letter-spacing: 0.1em;
+  letter-spacing: 0.08em;
   text-transform: uppercase;
   cursor: pointer;
   transition: transform 0.3s ease, border-color 0.3s ease, box-shadow 0.3s ease, background 0.3s ease;
@@ -342,34 +377,43 @@ button {
   --chip-rgb: var(--chip-rgb, 225, 6, 0);
 }
 
-.series-chip input {
+.series-toggle input {
   position: absolute;
   inset: 0;
   opacity: 0;
   pointer-events: none;
 }
 
-.series-chip__indicator {
-  width: 10px;
-  height: 10px;
-  border-radius: 50%;
-  background: rgba(var(--chip-rgb), 0.6);
-  box-shadow: 0 0 0 4px rgba(var(--chip-rgb), 0.18);
+.series-toggle__logo {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 64px;
+  transition: filter 0.3s ease, opacity 0.3s ease;
+  filter: drop-shadow(0 16px 34px rgba(var(--chip-rgb), 0.22));
 }
 
-.series-chip[data-active='true'] {
+.series-toggle__name {
+  font-size: 0.78rem;
+  letter-spacing: 0.14em;
+}
+
+.series-toggle[data-active='true'] {
   background: linear-gradient(140deg, rgba(var(--chip-rgb), 0.35), rgba(255, 255, 255, 0.08));
-  border-color: rgba(var(--chip-rgb), 0.5);
-  box-shadow: 0 16px 40px -28px rgba(var(--chip-rgb), 0.8);
+  border-color: rgba(var(--chip-rgb), 0.52);
+  box-shadow: 0 18px 44px -32px rgba(var(--chip-rgb), 0.8);
   transform: translateY(-1px);
 }
 
-.series-chip[data-active='true'] .series-chip__indicator {
-  background: rgba(var(--chip-rgb), 0.9);
-  box-shadow: 0 0 0 6px rgba(var(--chip-rgb), 0.2);
+.series-toggle[data-active='true'] .series-toggle__logo {
+  filter: drop-shadow(0 22px 50px rgba(var(--chip-rgb), 0.32));
 }
 
-.series-chip:hover {
+.series-toggle[data-active='false'] .series-toggle__logo {
+  opacity: 0.75;
+}
+
+.series-toggle:hover {
   transform: translateY(-2px);
   border-color: rgba(255, 255, 255, 0.22);
 }
@@ -649,7 +693,7 @@ button {
 }
 
 .period-button:focus-visible,
-.series-chip:focus-within,
+.series-toggle:focus-within,
 .timezone-chip:focus-visible {
   outline: 2px solid rgba(255, 255, 255, 0.45);
   outline-offset: 2px;
@@ -661,7 +705,7 @@ button {
     gap: clamp(24px, 8vw, 36px);
   }
 
-  .hero__controls {
+  .top-menu {
     grid-template-columns: 1fr;
   }
 }
@@ -689,7 +733,7 @@ button {
 }
 
 @media (max-width: 540px) {
-  .hero__controls {
+  .top-menu {
     grid-template-columns: 1fr;
   }
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -340,7 +340,7 @@ export default function Home() {
           <div className="hero__stat">
             <span className="hero__stat-label">Активные серии</span>
             <span className="hero__stat-value">{activeSeriesLabel}</span>
-            <span className="hero__stat-meta">переключите ниже</span>
+            <span className="hero__stat-meta">управляйте в верхнем меню</span>
           </div>
           <div className="hero__stat hero__stat--accent">
             <span className="hero__stat-label">Ближайший старт</span>
@@ -371,17 +371,21 @@ export default function Home() {
         </div>
       </section>
 
-      <section className="control-panel">
-        <div className="control-panel__group">
-          <span className="control-panel__label">Серии</span>
-          <div className="series-chips">
+      <section className="top-menu">
+        <div className="top-menu__series">
+          <div className="top-menu__series-header">
+            <span className="control-panel__label">Серии</span>
+            <span className="top-menu__active-summary">Активно: {activeSeriesLabel}</span>
+          </div>
+          <div className="top-menu__series-list">
             {SERIES_IDS.map(series => {
               const definition = SERIES_DEFINITIONS[series];
+              const isActive = visibleSeries[series];
               return (
                 <label
                   key={series}
-                  className="series-chip"
-                  data-active={visibleSeries[series]}
+                  className="series-toggle"
+                  data-active={isActive}
                   style={
                     {
                       '--chip-color': definition.accentColor,
@@ -391,7 +395,7 @@ export default function Home() {
                 >
                   <input
                     type="checkbox"
-                    checked={visibleSeries[series]}
+                    checked={isActive}
                     onChange={() =>
                       setVisibleSeries(prev => ({
                         ...prev,
@@ -399,68 +403,37 @@ export default function Home() {
                       }))
                     }
                   />
-                  <span className="series-chip__indicator" aria-hidden />
-                  <span>{definition.label}</span>
+                  <span className="series-toggle__logo">
+                    <SeriesLogo series={series} />
+                  </span>
+                  <span className="series-toggle__name">{definition.label}</span>
                 </label>
               );
             })}
           </div>
-          <div className="hero__controls">
-            <div className="control-panel__group">
-              <span className="control-panel__label">Серии</span>
-              <div className="series-chips">
-                {(['F1', 'F2', 'F3'] as Row['series'][]).map(series => (
-                  <label
-                    key={series}
-                    className="series-chip"
-                    data-active={visibleSeries[series]}
-                    style={
-                      {
-                        '--chip-color': SERIES_COLORS[series],
-                        '--chip-rgb': SERIES_ACCENT_RGB[series],
-                      } as CSSProperties
-                    }
-                  >
-                    <input
-                      type="checkbox"
-                      checked={visibleSeries[series]}
-                      onChange={() =>
-                        setVisibleSeries(prev => ({
-                          ...prev,
-                          [series]: !prev[series],
-                        }))
-                      }
-                    />
-                    <span className="series-chip__indicator" aria-hidden />
-                    <span>{series}</span>
-                  </label>
-                ))}
-              </div>
+        </div>
+        <div className="top-menu__filters">
+          <div className="control-panel__group">
+            <span className="control-panel__label">Период обзора</span>
+            <div className="period-buttons">
+              {PERIOD_OPTIONS.map(opt => (
+                <button
+                  key={opt.label}
+                  type="button"
+                  className="period-button"
+                  data-active={hours === opt.value}
+                  onClick={() => setHours(opt.value)}
+                >
+                  {opt.label}
+                </button>
+              ))}
             </div>
-
-            <div className="control-panel__group">
-              <span className="control-panel__label">Период обзора</span>
-              <div className="period-buttons">
-                {PERIOD_OPTIONS.map(opt => (
-                  <button
-                    key={opt.label}
-                    type="button"
-                    className="period-button"
-                    data-active={hours === opt.value}
-                    onClick={() => setHours(opt.value)}
-                  >
-                    {opt.label}
-                  </button>
-                ))}
-              </div>
-            </div>
-
-            <div className="control-panel__group">
-              <span className="control-panel__label">Часовой пояс</span>
-              <div className="timezone-chip">
-                <span className="timezone-chip__dot" aria-hidden />
-                <span>{userTz}</span>
-              </div>
+          </div>
+          <div className="control-panel__group">
+            <span className="control-panel__label">Часовой пояс</span>
+            <div className="timezone-chip">
+              <span className="timezone-chip__dot" aria-hidden />
+              <span>{userTz}</span>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- combine the series filters with their visual display in a single top menu section
- add logo-based series toggles and update styles to support the new layout
- adjust hero copy to reflect the relocated controls

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c89347b30883319ab1f4575aec8238