### PR TITLE
feat: merge series filters into top menu

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -224,7 +224,7 @@ button {
 .hero__stat-value,
 .hero__stat-meta--highlight,
 .control-panel__label,
-.series-chip,
+.series-toggle,
 .period-button,
 .timezone-chip,
 .event-card__series-pill,
@@ -285,11 +285,11 @@ button {
   font-weight: 600;
 }
 
-.hero__controls {
+.top-menu {
   position: relative;
   z-index: 1;
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  grid-template-columns: minmax(0, 1.35fr) minmax(0, 1fr);
   gap: clamp(18px, 4vw, 28px);
   padding: clamp(22px, 4vw, 32px);
   border-radius: clamp(22px, 4vw, 30px);
@@ -298,7 +298,43 @@ button {
   box-shadow: var(--shadow-ambient);
   backdrop-filter: blur(18px);
   min-width: 0;
-  align-self: stretch;
+  align-items: start;
+}
+
+.top-menu__series {
+  display: flex;
+  flex-direction: column;
+  gap: clamp(14px, 3vw, 20px);
+  min-width: 0;
+}
+
+.top-menu__filters {
+  display: flex;
+  flex-direction: column;
+  gap: clamp(18px, 3vw, 24px);
+  min-width: 0;
+}
+
+.top-menu__series-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.top-menu__active-summary {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  color: rgba(255, 255, 255, 0.58);
+  font-weight: 600;
+}
+
+.top-menu__series-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 14px;
 }
 
 .control-panel__group {
@@ -316,25 +352,24 @@ button {
   font-weight: 700;
 }
 
-.series-chips,
 .period-buttons {
   display: flex;
   flex-wrap: wrap;
   gap: 12px;
 }
 
-.series-chip {
+.series-toggle {
   position: relative;
   display: inline-flex;
   align-items: center;
-  gap: 10px;
-  padding: 10px 16px;
-  border-radius: 999px;
+  gap: 14px;
+  padding: 12px 18px 12px 12px;
+  border-radius: 18px;
   border: 1px solid rgba(255, 255, 255, 0.12);
   background: rgba(14, 18, 30, 0.65);
   color: #ffffff;
   font-weight: 700;
-  letter-spacing: 0.1em;
+  letter-spacing: 0.08em;
   text-transform: uppercase;
   cursor: pointer;
   transition: transform 0.3s ease, border-color 0.3s ease, box-shadow 0.3s ease, background 0.3s ease;
@@ -342,34 +377,43 @@ button {
   --chip-rgb: var(--chip-rgb, 225, 6, 0);
 }
 
-.series-chip input {
+.series-toggle input {
   position: absolute;
   inset: 0;
   opacity: 0;
   pointer-events: none;
 }
 
-.series-chip__indicator {
-  width: 10px;
-  height: 10px;
-  border-radius: 50%;
-  background: rgba(var(--chip-rgb), 0.6);
-  box-shadow: 0 0 0 4px rgba(var(--chip-rgb), 0.18);
+.series-toggle__logo {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 64px;
+  transition: filter 0.3s ease, opacity 0.3s ease;
+  filter: drop-shadow(0 16px 34px rgba(var(--chip-rgb), 0.22));
 }
 
-.series-chip[data-active='true'] {
+.series-toggle__name {
+  font-size: 0.78rem;
+  letter-spacing: 0.14em;
+}
+
+.series-toggle[data-active='true'] {
   background: linear-gradient(140deg, rgba(var(--chip-rgb), 0.35), rgba(255, 255, 255, 0.08));
-  border-color: rgba(var(--chip-rgb), 0.5);
-  box-shadow: 0 16px 40px -28px rgba(var(--chip-rgb), 0.8);
+  border-color: rgba(var(--chip-rgb), 0.52);
+  box-shadow: 0 18px 44px -32px rgba(var(--chip-rgb), 0.8);
   transform: translateY(-1px);
 }
 
-.series-chip[data-active='true'] .series-chip__indicator {
-  background: rgba(var(--chip-rgb), 0.9);
-  box-shadow: 0 0 0 6px rgba(var(--chip-rgb), 0.2);
+.series-toggle[data-active='true'] .series-toggle__logo {
+  filter: drop-shadow(0 22px 50px rgba(var(--chip-rgb), 0.32));
 }
 
-.series-chip:hover {
+.series-toggle[data-active='false'] .series-toggle__logo {
+  opacity: 0.75;
+}
+
+.series-toggle:hover {
   transform: translateY(-2px);
   border-color: rgba(255, 255, 255, 0.22);
 }
@@ -649,7 +693,7 @@ button {
 }
 
 .period-button:focus-visible,
-.series-chip:focus-within,
+.series-toggle:focus-within,
 .timezone-chip:focus-visible {
   outline: 2px solid rgba(255, 255, 255, 0.45);
   outline-offset: 2px;
@@ -661,7 +705,7 @@ button {
     gap: clamp(24px, 8vw, 36px);
   }
 
-  .hero__controls {
+  .top-menu {
     grid-template-columns: 1fr;
   }
 }
@@ -689,7 +733,7 @@ button {
 }
 
 @media (max-width: 540px) {
-  .hero__controls {
+  .top-menu {
     grid-template-columns: 1fr;
   }
 

--- a/lib/series.tsx
+++ b/lib/series.tsx
@@ -1,0 +1,100 @@
+export type SeriesDefinition = {
+  label: string;
+  accentColor: string;
+  accentRgb: string;
+  logoBackground: string;
+  logoAccent: string;
+  renderLogoContent?: (context: { accent: string; label: string }) => JSX.Element;
+};
+
+export const SERIES_DEFINITIONS = {
+  F1: {
+    label: 'F1',
+    accentColor: '#e10600',
+    accentRgb: '225, 6, 0',
+    logoBackground: '#111',
+    logoAccent: '#e10600',
+    renderLogoContent: ({ accent }) => (
+      <>
+        <path d="M7 17h8l1.8-4H8.8l1.4-3.2h7.2L19.2 6H11c-.9 0-1.7.5-2.1 1.3L5.5 16c-.4.9.2 2 1.5 2Z" fill="#fff" />
+        <path
+          d="M33.5 6h-8.6l-3.4 7.5c-.6 1.4.3 3 1.8 3h9.6c1.3 0 2.6-.5 3.5-1.4l2.4-2.4c.6-.6.2-1.7-.7-1.7h-7.5l2.5-5Z"
+          fill={accent}
+        />
+      </>
+    ),
+  },
+  F2: {
+    label: 'F2',
+    accentColor: '#0090ff',
+    accentRgb: '0, 144, 255',
+    logoBackground: '#0090ff',
+    logoAccent: '#fff',
+    renderLogoContent: ({ accent, label }) => (
+      <>
+        <text
+          x="50%"
+          y="50%"
+          textAnchor="middle"
+          dominantBaseline="middle"
+          fill={accent}
+          fontFamily="var(--font-display, 'Manrope')"
+          fontSize={15}
+          letterSpacing={1.2}
+        >
+          {label}
+        </text>
+        <path d="M9 7h14l-1.4 3.2H15l-.8 1.8h6.4L19 15H9l3-8Z" fill="#fff" />
+      </>
+    ),
+  },
+  F3: {
+    label: 'F3',
+    accentColor: '#ff6f00',
+    accentRgb: '255, 111, 0',
+    logoBackground: '#ff6f00',
+    logoAccent: '#fff',
+    renderLogoContent: ({ accent, label }) => (
+      <>
+        <text
+          x="50%"
+          y="50%"
+          textAnchor="middle"
+          dominantBaseline="middle"
+          fill={accent}
+          fontFamily="var(--font-display, 'Manrope')"
+          fontSize={15}
+          letterSpacing={1.2}
+        >
+          {label}
+        </text>
+        <path
+          d="M9 7h15c1 0 1.6 1.1 1.1 2l-1 1.8c.4.3.6.9.4 1.4l-1 2.4c-.2.7-.9 1.2-1.7 1.2H10l1.4-3.2h7.2l.4-.8h-6.6l1.2-2.8h7.6l.4-.8H10.8L9 7Z"
+          fill="#fff"
+        />
+      </>
+    ),
+  },
+} as const satisfies Record<string, SeriesDefinition>;
+
+export type SeriesId = keyof typeof SERIES_DEFINITIONS;
+
+export const SERIES_IDS = Object.keys(SERIES_DEFINITIONS) as SeriesId[];
+
+export const DEFAULT_SERIES_ID = SERIES_IDS[0];
+
+export const FALLBACK_SERIES_DEFINITION =
+  DEFAULT_SERIES_ID ? SERIES_DEFINITIONS[DEFAULT_SERIES_ID] : undefined;
+
+export function isSeriesId(value: string): value is SeriesId {
+  return Object.prototype.hasOwnProperty.call(SERIES_DEFINITIONS, value);
+}
+
+export function buildSeriesVisibility(value: boolean): Record<SeriesId, boolean> {
+  return SERIES_IDS.reduce((acc, series) => {
+    acc[series] = value;
+    return acc;
+  }, {} as Record<SeriesId, boolean>);
+}
+
+export const SERIES_TITLE = SERIES_IDS.map(series => SERIES_DEFINITIONS[series].label).join(' / ');


### PR DESCRIPTION
## Summary
- combine the series filters with their visual display in a single top menu section
- add logo-based series toggles and update styles to support the new layout
- adjust hero copy to reflect the relocated controls
- refactor series metadata into a shared module to align with main-branch updates

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c89347b30883319ab1f4575aec8238