### PR TITLE
Combine series filter and selection display

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -308,6 +308,31 @@ button {
   min-width: 0;
 }
 
+.control-panel__group--series {
+  gap: 16px;
+}
+
+.control-panel__group-header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 8px 12px;
+}
+
+.control-panel__selection {
+  font-size: 0.85rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  line-height: 1.3;
+  color: rgba(255, 255, 255, 0.72);
+  text-transform: none;
+}
+
+.control-panel__selection[data-empty='true'] {
+  color: rgba(255, 255, 255, 0.45);
+}
+
 .control-panel__label {
   font-size: 0.75rem;
   text-transform: uppercase;

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -285,9 +285,11 @@ export default function Home() {
   const activeSeries = (Object.entries(visibleSeries) as [SeriesId, boolean][])
     .filter(([, active]) => active)
     .map(([series]) => series);
-  const activeSeriesLabel = activeSeries.length
-    ? activeSeries.map(series => SERIES_DEFINITIONS[series].label).join(' · ')
-    : 'Нет';
+  const activeSeriesNames = activeSeries.map(series => SERIES_DEFINITIONS[series].label);
+  const hasActiveSeries = activeSeriesNames.length > 0;
+  const activeSeriesSelection = hasActiveSeries
+    ? `Выбрано: ${activeSeriesNames.join(' · ')}`
+    : 'Все серии скрыты';
   const selectedPeriodLabel =
     PERIOD_OPTIONS.find(opt => opt.value === hours)?.label ?? '30 дней';
   const nextEvent = filtered[0];
@@ -337,11 +339,6 @@ export default function Home() {
           горизонтом просмотра и следите за временем старта в собственном часовом поясе.
         </p>
         <div className="hero__stats">
-          <div className="hero__stat">
-            <span className="hero__stat-label">Активные серии</span>
-            <span className="hero__stat-value">{activeSeriesLabel}</span>
-            <span className="hero__stat-meta">переключите ниже</span>
-          </div>
           <div className="hero__stat hero__stat--accent">
             <span className="hero__stat-label">Ближайший старт</span>
             {nextEvent && nextLocal ? (
@@ -373,8 +370,17 @@ export default function Home() {
 
       <section className="control-panel">
         <div className="hero__controls">
-          <div className="control-panel__group">
-            <span className="control-panel__label">Серии</span>
+          <div className="control-panel__group control-panel__group--series">
+            <div className="control-panel__group-header">
+              <span className="control-panel__label">Серии</span>
+              <span
+                className="control-panel__selection"
+                aria-live="polite"
+                data-empty={!hasActiveSeries}
+              >
+                {activeSeriesSelection}
+              </span>
+            </div>
             <div className="series-chips">
               {SERIES_IDS.map(series => {
                 const definition = SERIES_DEFINITIONS[series];


### PR DESCRIPTION
## Summary
- surface the selected series summary directly inside the filter block
- remove the separate hero stat for active series and add styles for the merged header

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c89beb6f808331977fb8940a3004ae