### PR TITLE
Add custom favicon

### DIFF
--- a/app/icon.svg
+++ b/app/icon.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <rect width="64" height="64" rx="14" fill="#e10600"/>
+  <path fill="#ffffff" d="M16 19h24l-2.8 7H25v7h12.5L34.6 40H16z"/>
+  <path fill="#ffffff" d="M45 21h-6l-1.7 5H41v18h6V21z"/>
+</svg>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -18,7 +18,10 @@ export const metadata: Metadata = {
   title: 'F1/F2/F3 schedule',
   description: 'Upcoming qualifying & race times (your time zone)',
   icons: {
-    icon: '/favicon.svg',
+    icon: [
+      { rel: 'icon', url: '/icon.svg', type: 'image/svg+xml' },
+      { rel: 'alternate icon', url: '/favicon.svg', type: 'image/svg+xml' },
+    ],
   },
 };
 


### PR DESCRIPTION
## Summary
- add a custom SVG favicon for the schedule app
- expose the favicon through Next.js metadata so browsers show it in the address bar

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c89ce32b1483319b261d14e336ecae