### PR TITLE
Rearrange hero footer to align filters and next event

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -223,6 +223,8 @@ button {
 .hero__stat-label,
 .hero__stat-value,
 .hero__stat-meta--highlight,
+.hero__event-summary-label,
+.hero__event-summary-value,
 .control-panel__label,
 .series-chip,
 .period-button,
@@ -235,12 +237,72 @@ button {
   font-family: var(--font-display), var(--font-sans), 'Manrope', sans-serif;
 }
 
-.hero__stats {
+.hero__footer {
   position: relative;
   z-index: 1;
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  grid-template-columns: minmax(0, 1.3fr) minmax(0, 1fr) minmax(0, 1.1fr);
+  gap: clamp(18px, 4vw, 28px);
+  align-items: stretch;
+}
+
+.hero__footer-column {
+  display: flex;
+  flex-direction: column;
   gap: clamp(14px, 3vw, 20px);
+  min-width: 0;
+}
+
+.hero__footer-column--series {
+  gap: clamp(16px, 3vw, 22px);
+}
+
+.hero__footer-column--stat .hero__stat {
+  height: 100%;
+}
+
+.hero__footer-meta {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  min-width: 0;
+}
+
+.hero__event-summary {
+  padding: 18px 20px;
+  border-radius: 20px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  background: rgba(255, 255, 255, 0.04);
+  backdrop-filter: blur(12px);
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.hero__event-summary-label {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  color: rgba(255, 255, 255, 0.62);
+  font-weight: 700;
+}
+
+.hero__event-summary-value {
+  font-size: clamp(1.2rem, 2.8vw, 1.8rem);
+  font-weight: 700;
+  letter-spacing: 0.02em;
+}
+
+.hero__event-summary-period {
+  font-size: 0.85rem;
+  color: rgba(255, 255, 255, 0.68);
+  letter-spacing: 0.02em;
+}
+
+.hero__timezone {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
 }
 
 .hero__stat {
@@ -285,27 +347,36 @@ button {
   font-weight: 600;
 }
 
-.hero__controls {
-  position: relative;
-  z-index: 1;
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
-  gap: clamp(18px, 4vw, 28px);
-  padding: clamp(22px, 4vw, 32px);
-  border-radius: clamp(22px, 4vw, 30px);
-  border: 1px solid rgba(255, 255, 255, 0.08);
-  background: rgba(10, 14, 24, 0.72);
-  box-shadow: var(--shadow-ambient);
-  backdrop-filter: blur(18px);
-  min-width: 0;
-  align-self: stretch;
-}
-
 .control-panel__group {
   display: flex;
   flex-direction: column;
   gap: 12px;
   min-width: 0;
+}
+
+.control-panel__group--series {
+  gap: 16px;
+}
+
+.control-panel__group-header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 8px 12px;
+}
+
+.control-panel__selection {
+  font-size: 0.85rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  line-height: 1.3;
+  color: rgba(255, 255, 255, 0.72);
+  text-transform: none;
+}
+
+.control-panel__selection[data-empty='true'] {
+  color: rgba(255, 255, 255, 0.45);
 }
 
 .control-panel__label {
@@ -656,13 +727,8 @@ button {
 }
 
 @media (max-width: 960px) {
-  .hero__grid {
-    grid-template-columns: 1fr;
-    gap: clamp(24px, 8vw, 36px);
-  }
-
-  .hero__controls {
-    grid-template-columns: 1fr;
+  .hero__footer {
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
   }
 }
 
@@ -679,7 +745,7 @@ button {
 }
 
 @media (max-width: 720px) {
-  .hero__stats {
+  .hero__footer {
     grid-template-columns: 1fr;
   }
 
@@ -689,10 +755,6 @@ button {
 }
 
 @media (max-width: 540px) {
-  .hero__controls {
-    grid-template-columns: 1fr;
-  }
-
   .hero__badge {
     font-size: 0.72rem;
   }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -285,9 +285,11 @@ export default function Home() {
   const activeSeries = (Object.entries(visibleSeries) as [SeriesId, boolean][])
     .filter(([, active]) => active)
     .map(([series]) => series);
-  const activeSeriesLabel = activeSeries.length
-    ? activeSeries.map(series => SERIES_DEFINITIONS[series].label).join(' · ')
-    : 'Нет';
+  const activeSeriesNames = activeSeries.map(series => SERIES_DEFINITIONS[series].label);
+  const hasActiveSeries = activeSeriesNames.length > 0;
+  const activeSeriesSelection = hasActiveSeries
+    ? `Выбрано: ${activeSeriesNames.join(' · ')}`
+    : 'Все серии скрыты';
   const selectedPeriodLabel =
     PERIOD_OPTIONS.find(opt => opt.value === hours)?.label ?? '30 дней';
   const nextEvent = filtered[0];
@@ -336,100 +338,107 @@ export default function Home() {
           Синхронизируйтесь с динамикой гоночных уик-эндов: фильтруйте серии, управляйте
           горизонтом просмотра и следите за временем старта в собственном часовом поясе.
         </p>
-        <div className="hero__stats">
-          <div className="hero__stat">
-            <span className="hero__stat-label">Активные серии</span>
-            <span className="hero__stat-value">{activeSeriesLabel}</span>
-            <span className="hero__stat-meta">переключите ниже</span>
-          </div>
-          <div className="hero__stat hero__stat--accent">
-            <span className="hero__stat-label">Ближайший старт</span>
-            {nextEvent && nextLocal ? (
-              <>
-                <span className="hero__stat-value">{nextLocal.toFormat('dd LLL • HH:mm')}</span>
-                <span className="hero__stat-meta">
-                  {nextSeriesLabel} · {nextDescriptor}
-                </span>
-                {nextCountdown && (
-                  <span className="hero__stat-meta hero__stat-meta--highlight">
-                    {nextCountdown}
-                  </span>
-                )}
-              </>
-            ) : (
-              <>
-                <span className="hero__stat-value">Нет событий</span>
-                <span className="hero__stat-meta">Попробуйте расширить период</span>
-              </>
-            )}
-          </div>
-          <div className="hero__stat">
-            <span className="hero__stat-label">Событий в окне</span>
-            <span className="hero__stat-value">{filtered.length}</span>
-            <span className="hero__stat-meta">{selectedPeriodLabel}</span>
-          </div>
-        </div>
-      </section>
-
-      <section className="control-panel">
-        <div className="hero__controls">
-          <div className="control-panel__group">
-            <span className="control-panel__label">Серии</span>
-            <div className="series-chips">
-              {SERIES_IDS.map(series => {
-                const definition = SERIES_DEFINITIONS[series];
-                return (
-                  <label
-                    key={series}
-                    className="series-chip"
-                    data-active={visibleSeries[series]}
-                    style={
-                      {
-                        '--chip-color': definition.accentColor,
-                        '--chip-rgb': definition.accentRgb,
-                      } as CSSProperties
-                    }
-                  >
-                    <input
-                      type="checkbox"
-                      checked={visibleSeries[series]}
-                      onChange={() =>
-                        setVisibleSeries(prev => ({
-                          ...prev,
-                          [series]: !prev[series],
-                        }))
-                      }
-                    />
-                    <span className="series-chip__indicator" aria-hidden />
-                    <span>{definition.label}</span>
-                  </label>
-                );
-              })}
-            </div>
-          </div>
-
-          <div className="control-panel__group">
-            <span className="control-panel__label">Период обзора</span>
-            <div className="period-buttons">
-              {PERIOD_OPTIONS.map(opt => (
-                <button
-                  key={opt.label}
-                  type="button"
-                  className="period-button"
-                  data-active={hours === opt.value}
-                  onClick={() => setHours(opt.value)}
+        <div className="hero__footer">
+          <div className="hero__footer-column hero__footer-column--series">
+            <div className="control-panel__group control-panel__group--series">
+              <div className="control-panel__group-header">
+                <span className="control-panel__label">Серии</span>
+                <span
+                  className="control-panel__selection"
+                  aria-live="polite"
+                  data-empty={!hasActiveSeries}
                 >
-                  {opt.label}
-                </button>
-              ))}
+                  {activeSeriesSelection}
+                </span>
+              </div>
+              <div className="series-chips">
+                {SERIES_IDS.map(series => {
+                  const definition = SERIES_DEFINITIONS[series];
+                  return (
+                    <label
+                      key={series}
+                      className="series-chip"
+                      data-active={visibleSeries[series]}
+                      style={
+                        {
+                          '--chip-color': definition.accentColor,
+                          '--chip-rgb': definition.accentRgb,
+                        } as CSSProperties
+                      }
+                    >
+                      <input
+                        type="checkbox"
+                        checked={visibleSeries[series]}
+                        onChange={() =>
+                          setVisibleSeries(prev => ({
+                            ...prev,
+                            [series]: !prev[series],
+                          }))
+                        }
+                      />
+                      <span className="series-chip__indicator" aria-hidden />
+                      <span>{definition.label}</span>
+                    </label>
+                  );
+                })}
+              </div>
             </div>
           </div>
 
-          <div className="control-panel__group">
-            <span className="control-panel__label">Часовой пояс</span>
-            <div className="timezone-chip">
-              <span className="timezone-chip__dot" aria-hidden />
-              <span>{userTz}</span>
+          <div className="hero__footer-column hero__footer-column--stat">
+            <div className="hero__stat hero__stat--accent">
+              <span className="hero__stat-label">Ближайший старт</span>
+              {nextEvent && nextLocal ? (
+                <>
+                  <span className="hero__stat-value">{nextLocal.toFormat('dd LLL • HH:mm')}</span>
+                  <span className="hero__stat-meta">
+                    {nextSeriesLabel} · {nextDescriptor}
+                  </span>
+                  {nextCountdown && (
+                    <span className="hero__stat-meta hero__stat-meta--highlight">
+                      {nextCountdown}
+                    </span>
+                  )}
+                </>
+              ) : (
+                <>
+                  <span className="hero__stat-value">Нет событий</span>
+                  <span className="hero__stat-meta">Попробуйте расширить период</span>
+                </>
+              )}
+            </div>
+          </div>
+
+          <div className="hero__footer-column hero__footer-column--period">
+            <div className="control-panel__group">
+              <span className="control-panel__label">Период обзора</span>
+              <div className="period-buttons">
+                {PERIOD_OPTIONS.map(opt => (
+                  <button
+                    key={opt.label}
+                    type="button"
+                    className="period-button"
+                    data-active={hours === opt.value}
+                    onClick={() => setHours(opt.value)}
+                  >
+                    {opt.label}
+                  </button>
+                ))}
+              </div>
+            </div>
+            <div className="hero__footer-meta">
+              <div className="hero__event-summary">
+                <span className="hero__event-summary-label">Событий в окне</span>
+                <span className="hero__event-summary-value">{filtered.length}</span>
+                <span className="hero__event-summary-period">{selectedPeriodLabel}</span>
+              </div>
+              <div className="hero__timezone">
+                <span className="control-panel__label">Часовой пояс</span>
+                <div className="timezone-chip">
+                  <span className="timezone-chip__dot" aria-hidden />
+                  <span>{userTz}</span>
+                </div>
+              </div>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- move series chips, next event details, and period controls into a single hero footer with left/center/right alignment
- add an inline event count with timezone context beside the period buttons and drop the separate control panel section

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c89beb6f808331977fb8940a3004ae