### PR TITLE
Combine review period and event summary panel

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -268,7 +268,7 @@ button {
   min-width: 0;
 }
 
-.hero__event-summary {
+.hero__period-card {
   padding: 18px 20px;
   border-radius: 20px;
   border: 1px solid rgba(255, 255, 255, 0.12);
@@ -276,7 +276,26 @@ button {
   backdrop-filter: blur(12px);
   display: flex;
   flex-direction: column;
-  gap: 6px;
+  gap: 18px;
+}
+
+.hero__period-card-controls {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.hero__event-summary {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.hero__event-summary-values {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: 10px 16px;
 }
 
 .hero__event-summary-label {

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -410,34 +410,36 @@ export default function Home() {
           </div>
 
           <div className="hero__footer-column hero__footer-column--period">
-            <div className="control-panel__group">
-              <span className="control-panel__label">Период обзора</span>
-              <div className="period-buttons">
-                {PERIOD_OPTIONS.map(opt => (
-                  <button
-                    key={opt.label}
-                    type="button"
-                    className="period-button"
-                    data-active={hours === opt.value}
-                    onClick={() => setHours(opt.value)}
-                  >
-                    {opt.label}
-                  </button>
-                ))}
+            <div className="hero__period-card">
+              <div className="hero__period-card-controls">
+                <span className="control-panel__label">Период обзора</span>
+                <div className="period-buttons">
+                  {PERIOD_OPTIONS.map(opt => (
+                    <button
+                      key={opt.label}
+                      type="button"
+                      className="period-button"
+                      data-active={hours === opt.value}
+                      onClick={() => setHours(opt.value)}
+                    >
+                      {opt.label}
+                    </button>
+                  ))}
+                </div>
               </div>
-            </div>
-            <div className="hero__footer-meta">
               <div className="hero__event-summary">
                 <span className="hero__event-summary-label">Событий в окне</span>
-                <span className="hero__event-summary-value">{filtered.length}</span>
-                <span className="hero__event-summary-period">{selectedPeriodLabel}</span>
-              </div>
-              <div className="hero__timezone">
-                <span className="control-panel__label">Часовой пояс</span>
-                <div className="timezone-chip">
-                  <span className="timezone-chip__dot" aria-hidden />
-                  <span>{userTz}</span>
+                <div className="hero__event-summary-values">
+                  <span className="hero__event-summary-value">{filtered.length}</span>
+                  <span className="hero__event-summary-period">{selectedPeriodLabel}</span>
                 </div>
+              </div>
+            </div>
+            <div className="hero__timezone">
+              <span className="control-panel__label">Часовой пояс</span>
+              <div className="timezone-chip">
+                <span className="timezone-chip__dot" aria-hidden />
+                <span>{userTz}</span>
               </div>
             </div>
           </div>


### PR DESCRIPTION
## Summary
- combine the review period controls and event count into a single panel
- update the markup to group the event total with its label and selected period
- add styling for the new combined card layout

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c90d2e88c083318c4de8271c9ae21f