### PR TITLE
Reorganize hero period section layout

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -279,10 +279,20 @@ button {
   gap: 18px;
 }
 
+.hero__period-card-header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 18px 24px;
+}
+
 .hero__period-card-controls {
   display: flex;
   flex-direction: column;
   gap: 12px;
+  flex: 1 1 240px;
+  min-width: min(320px, 100%);
 }
 
 .hero__event-summary {
@@ -320,8 +330,13 @@ button {
 
 .hero__timezone {
   display: flex;
-  flex-direction: column;
-  gap: 10px;
+  align-items: center;
+  gap: 12px;
+  min-width: fit-content;
+}
+
+.hero__timezone .control-panel__label {
+  white-space: nowrap;
 }
 
 .hero__stat {
@@ -770,6 +785,18 @@ button {
 
   .page-shell {
     padding: clamp(32px, 6vw, 56px) clamp(16px, 6vw, 36px) clamp(72px, 10vw, 100px);
+  }
+
+  .hero__period-card-header {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 16px;
+  }
+
+  .hero__timezone {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 8px;
   }
 }
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -411,20 +411,29 @@ export default function Home() {
 
           <div className="hero__footer-column hero__footer-column--period">
             <div className="hero__period-card">
-              <div className="hero__period-card-controls">
-                <span className="control-panel__label">Период обзора</span>
-                <div className="period-buttons">
-                  {PERIOD_OPTIONS.map(opt => (
-                    <button
-                      key={opt.label}
-                      type="button"
-                      className="period-button"
-                      data-active={hours === opt.value}
-                      onClick={() => setHours(opt.value)}
-                    >
-                      {opt.label}
-                    </button>
-                  ))}
+              <div className="hero__period-card-header">
+                <div className="hero__period-card-controls">
+                  <span className="control-panel__label">Период обзора</span>
+                  <div className="period-buttons">
+                    {PERIOD_OPTIONS.map(opt => (
+                      <button
+                        key={opt.label}
+                        type="button"
+                        className="period-button"
+                        data-active={hours === opt.value}
+                        onClick={() => setHours(opt.value)}
+                      >
+                        {opt.label}
+                      </button>
+                    ))}
+                  </div>
+                </div>
+                <div className="hero__timezone">
+                  <span className="control-panel__label">Часовой пояс</span>
+                  <div className="timezone-chip">
+                    <span className="timezone-chip__dot" aria-hidden />
+                    <span>{userTz}</span>
+                  </div>
                 </div>
               </div>
               <div className="hero__event-summary">
@@ -433,13 +442,6 @@ export default function Home() {
                   <span className="hero__event-summary-value">{filtered.length}</span>
                   <span className="hero__event-summary-period">{selectedPeriodLabel}</span>
                 </div>
-              </div>
-            </div>
-            <div className="hero__timezone">
-              <span className="control-panel__label">Часовой пояс</span>
-              <div className="timezone-chip">
-                <span className="timezone-chip__dot" aria-hidden />
-                <span>{userTz}</span>
               </div>
             </div>
           </div>


### PR DESCRIPTION
## Summary
- move the timezone chip into the period card header so it sits on the top row beside the period controls
- tweak hero period card styling to tighten spacing and keep the new layout responsive on smaller screens

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c91f5e749883319545b5ee813582cf