### PR TITLE
Add timezone label to hero badge

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -177,6 +177,29 @@ button {
   backdrop-filter: blur(12px);
 }
 
+.hero__badge-text {
+  display: inline-flex;
+  align-items: center;
+}
+
+.hero__badge-timezone {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: none;
+  color: rgba(255, 255, 255, 0.72);
+}
+
+.hero__badge-timezone::before {
+  content: '•';
+  font-size: 0.9em;
+  line-height: 1;
+  color: rgba(255, 255, 255, 0.56);
+  letter-spacing: normal;
+}
+
 .hero__pulse {
   width: 10px;
   height: 10px;

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -282,6 +282,10 @@ export default function Home() {
   }, [rows, visibleSeries, hours]);
 
   const nowLocal = DateTime.local().setZone(userTz);
+  const timezoneOffset = nowLocal.toFormat('ZZ');
+  const timezoneBadgeLabel = userTz?.trim().length
+    ? `${userTz} (UTC${timezoneOffset})`
+    : `UTC${timezoneOffset}`;
   const activeSeries = (Object.entries(visibleSeries) as [SeriesId, boolean][])
     .filter(([, active]) => active)
     .map(([series]) => series);
@@ -329,7 +333,8 @@ export default function Home() {
       >
         <span className="hero__badge">
           <span className="hero__pulse" aria-hidden />
-          живой календарь уик-эндов
+          <span className="hero__badge-text">живой календарь уик-эндов</span>
+          <span className="hero__badge-timezone">{timezoneBadgeLabel}</span>
         </span>
         <h1 className="hero__title">
           Ближайшие квалификации и гонки — {SERIES_TITLE || 'F1 / F2 / F3'}


### PR DESCRIPTION
## Summary
- show the detected timezone and UTC offset next to the hero badge text
- add styling so the timezone label aligns with the existing hero badge visuals

## Testing
- npm run lint *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68c921cc8ad083319e9b579535eeb424