### PR TITLE
Remove timezone display from period card

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -251,7 +251,6 @@ button {
 .control-panel__label,
 .series-chip,
 .period-button,
-.timezone-chip,
 .event-card__series-pill,
 .event-card__datetime,
 .event-card__time,
@@ -349,17 +348,6 @@ button {
   font-size: 0.85rem;
   color: rgba(255, 255, 255, 0.68);
   letter-spacing: 0.02em;
-}
-
-.hero__timezone {
-  display: flex;
-  align-items: center;
-  gap: 12px;
-  min-width: fit-content;
-}
-
-.hero__timezone .control-panel__label {
-  white-space: nowrap;
 }
 
 .hero__stat {
@@ -525,29 +513,6 @@ button {
 .period-button:hover {
   transform: translateY(-2px);
   border-color: rgba(255, 255, 255, 0.2);
-}
-
-.timezone-chip {
-  display: inline-flex;
-  align-items: center;
-  gap: 10px;
-  align-self: flex-start;
-  padding: 10px 18px;
-  border-radius: 14px;
-  border: 1px solid rgba(255, 255, 255, 0.12);
-  background: rgba(14, 18, 30, 0.6);
-  font-weight: 600;
-  letter-spacing: 0.06em;
-  color: #ffffff;
-  box-shadow: 0 16px 34px -30px rgba(0, 0, 0, 0.8);
-}
-
-.timezone-chip__dot {
-  width: 8px;
-  height: 8px;
-  border-radius: 50%;
-  background: rgba(0, 144, 255, 0.85);
-  box-shadow: 0 0 0 6px rgba(0, 144, 255, 0.18);
 }
 
 .events-grid {
@@ -777,8 +742,7 @@ button {
 }
 
 .period-button:focus-visible,
-.series-chip:focus-within,
-.timezone-chip:focus-visible {
+.series-chip:focus-within {
   outline: 2px solid rgba(255, 255, 255, 0.45);
   outline-offset: 2px;
 }
@@ -814,12 +778,6 @@ button {
     flex-direction: column;
     align-items: stretch;
     gap: 16px;
-  }
-
-  .hero__timezone {
-    flex-direction: column;
-    align-items: flex-start;
-    gap: 8px;
   }
 }
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -433,13 +433,6 @@ export default function Home() {
                     ))}
                   </div>
                 </div>
-                <div className="hero__timezone">
-                  <span className="control-panel__label">Часовой пояс</span>
-                  <div className="timezone-chip">
-                    <span className="timezone-chip__dot" aria-hidden />
-                    <span>{userTz}</span>
-                  </div>
-                </div>
               </div>
               <div className="hero__event-summary">
                 <span className="hero__event-summary-label">Событий в окне</span>


### PR DESCRIPTION
## Summary
- remove the timezone selector from the period card so only review period controls remain
- delete unused timezone-related styles and references

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c925ff83248331a8b5eeed0f2b2556