### PR TITLE
Remove timezone text from event cards

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -569,11 +569,6 @@ button {
   font-size: 0.85rem;
 }
 
-.event-card__tz {
-  font-size: 0.75rem;
-  opacity: 0.7;
-}
-
 .event-card__title {
   display: flex;
   flex-wrap: wrap;

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -542,7 +542,6 @@ export default function Home() {
           const timeLabel = localized.toFormat('HH:mm');
           const dayLabel = localized.toFormat('ccc');
           const dateLabel = localized.toFormat('dd LLL');
-          const tzLabel = localized.toFormat('ZZZZ');
           const relative = localized.toRelative({ base: nowLocal, locale: 'ru', style: 'long' });
           const countdown = relative
             ? localized > nowLocal
@@ -585,7 +584,6 @@ export default function Home() {
                     <span className="event-card__date">
                       {dayLabel}, {dateLabel}
                     </span>
-                    <span className="event-card__tz">{tzLabel}</span>
                   </time>
                 </div>
                 <div className="event-card__title">


### PR DESCRIPTION
## Summary
- remove the timezone label from each event card so the timezone is only shown in the header badge
- clean up the corresponding event card timezone styles

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c996231a5083318926f1a6abb45309