### PR TITLE
Treat feature sessions as races

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -84,6 +84,7 @@ function normalizeSession(raw: string): Row['session'] | undefined {
     return 'Sprint';
   }
   if (lower.includes('qual') || /^Q\d+$/.test(upper)) return 'Qualifying';
+  if (lower.includes('feature')) return 'Race';
   if (lower.includes('race') || upper === 'RAC' || lower === 'grand prix' || upper === 'GP') return 'Race';
   return undefined;
 }


### PR DESCRIPTION
## Summary
- treat Feature-labelled sessions as races when parsing the schedule so the matching cards are rendered

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c9b8c28bbc8331bd8f2683588ffa3a