### PR TITLE
Adjust MotoGP accent color

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -36,8 +36,8 @@ const SERIES_DEFINITIONS = {
   },
   MotoGP: {
     label: 'MotoGP',
-    accentColor: '#ff1801',
-    accentRgb: '255, 24, 1',
+    accentColor: '#ff0050',
+    accentRgb: '255, 0, 80',
     logoBackground: '#fff',
     logoAsset: '/logos/motogp.svg',
   },


### PR DESCRIPTION
## Summary
- change the MotoGP accent color values to differentiate the series styling

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c9bc3d74708331929ab57128515250