### PR TITLE
Refine track rendering

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -638,23 +638,31 @@ button {
   aspect-ratio: 1 / 1;
 }
 
+.event-card__track-shadow,
 .event-card__track-outline,
-.event-card__track-path {
+.event-card__track-highlight {
   fill: none;
   stroke-linecap: round;
   stroke-linejoin: round;
 }
 
-.event-card__track-outline {
-  stroke: rgba(255, 255, 255, 0.2);
-  stroke-width: 48;
-  opacity: 0.65;
+.event-card__track-shadow {
+  stroke: rgba(var(--accent-rgb), 0.24);
+  stroke-width: 34;
+  filter: drop-shadow(0 26px 70px rgba(var(--accent-rgb), 0.4));
 }
 
-.event-card__track-path {
-  stroke: rgba(var(--accent-rgb), 0.85);
-  stroke-width: 26;
-  filter: drop-shadow(0 24px 60px rgba(var(--accent-rgb), 0.45));
+.event-card__track-outline {
+  stroke: rgba(12, 15, 24, 0.88);
+  stroke-width: 24;
+  filter: drop-shadow(0 18px 48px rgba(0, 0, 0, 0.55));
+}
+
+.event-card__track-highlight {
+  stroke: rgba(255, 255, 255, 0.9);
+  stroke-width: 10;
+  mix-blend-mode: screen;
+  filter: drop-shadow(0 14px 38px rgba(var(--accent-rgb), 0.45));
 }
 
 .event-card__countdown {

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -554,8 +554,9 @@ export default function Home() {
                       aria-label={trackLabel}
                       focusable="false"
                     >
+                      <path className="event-card__track-shadow" d={track.layout.path} />
                       <path className="event-card__track-outline" d={track.layout.path} />
-                      <path className="event-card__track-path" d={track.layout.path} />
+                      <path className="event-card__track-highlight" d={track.layout.path} />
                     </svg>
                   </div>
                 ) : null}


### PR DESCRIPTION
## Summary
- thin the circuit rendering by adding a layered stroke stack for shadow, asphalt, and highlight
- adjust the event card SVG markup to use the new layers for a more realistic track look

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c9c2b1c79c83319b65a9e3d7e30837