### PR TITLE
Move language switcher to hero top row

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -152,6 +152,36 @@ button {
   min-width: 0;
 }
 
+.hero__top-row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 12px 18px;
+}
+
+.hero__badge-wrapper {
+  display: flex;
+  flex: 1 1 320px;
+}
+
+.hero__language {
+  margin-left: auto;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 8px;
+  flex: 0 0 auto;
+}
+
+.hero__language-label {
+  align-self: flex-end;
+  text-align: right;
+}
+
+.hero__language .language-select {
+  justify-content: flex-end;
+}
+
 .hero__badge {
   position: relative;
   z-index: 1;

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -530,10 +530,41 @@ export default function Home() {
         }
       >
         <div className="hero__intro">
-          <span className="hero__badge">
-            <span className="hero__badge-text">{texts.heroBadge}</span>
-            <span className="hero__badge-timezone">{timezoneBadgeLabel}</span>
-          </span>
+          <div className="hero__top-row">
+            <div className="hero__badge-wrapper">
+              <span className="hero__badge">
+                <span className="hero__badge-text">{texts.heroBadge}</span>
+                <span className="hero__badge-timezone">{timezoneBadgeLabel}</span>
+              </span>
+            </div>
+            <div className="hero__language">
+              <label
+                className="hero__language-label control-panel__label"
+                htmlFor="language-select"
+              >
+                {texts.languageLabel}
+              </label>
+              <div className="language-select">
+                <select
+                  id="language-select"
+                  className="language-select__dropdown"
+                  value={language}
+                  onChange={event => {
+                    const value = event.target.value;
+                    if (isLanguageCode(value)) {
+                      setLanguage(value);
+                    }
+                  }}
+                >
+                  {LANGUAGE_CODES.map(code => (
+                    <option key={code} value={code}>
+                      {LANGUAGE_DEFINITIONS[code].name}
+                    </option>
+                  ))}
+                </select>
+              </div>
+            </div>
+          </div>
           <h1 className="hero__title">
             {texts.heroTitle(SERIES_TITLE || 'F1 / F2 / F3 / MotoGP')}
           </h1>
@@ -542,32 +573,6 @@ export default function Home() {
         <div className="hero__layout">
           <div className="hero__column">
             <div className="hero-card">
-              <div className="hero-card__section">
-                <div className="hero-card__section-header">
-                  <label className="control-panel__label" htmlFor="language-select">
-                    {texts.languageLabel}
-                  </label>
-                </div>
-                <div className="language-select">
-                  <select
-                    id="language-select"
-                    className="language-select__dropdown"
-                    value={language}
-                    onChange={event => {
-                      const value = event.target.value;
-                      if (isLanguageCode(value)) {
-                        setLanguage(value);
-                      }
-                    }}
-                  >
-                    {LANGUAGE_CODES.map(code => (
-                      <option key={code} value={code}>
-                        {LANGUAGE_DEFINITIONS[code].name}
-                      </option>
-                    ))}
-                  </select>
-                </div>
-              </div>
               <div className="hero-card__section">
                 <div className="hero-card__section-header">
                   <span className="control-panel__label">{texts.seriesLabel}</span>


### PR DESCRIPTION
## Summary
- move the language selector into the hero heading alongside the timezone badge
- add styles so the selector sits on the top-right and remove the redundant card section

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c9dbb9002883318bfa0265734ad577