### PR TITLE
Add placeholder track layout state for event cards

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -702,6 +702,22 @@ button {
   box-shadow: 0 30px 90px -60px rgba(var(--accent-rgb), 0.9);
 }
 
+.event-card__track--placeholder {
+  align-items: flex-start;
+  justify-content: flex-start;
+}
+
+.event-card__track--placeholder::after {
+  content: '';
+  position: absolute;
+  inset: clamp(12px, 2vw, 18px);
+  border-radius: 16px;
+  background: linear-gradient(140deg, rgba(var(--accent-rgb), 0.22), rgba(255, 255, 255, 0.08));
+  opacity: 0.65;
+  filter: blur(0.5px);
+  z-index: 0;
+}
+
 .event-card__track::before {
   content: '';
   position: absolute;
@@ -718,6 +734,29 @@ button {
   width: 100%;
   max-width: clamp(200px, 36vw, 260px);
   aspect-ratio: 1 / 1;
+}
+
+.event-card__track-placeholder {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  width: 100%;
+}
+
+.event-card__track-placeholder-title {
+  font-size: 0.78rem;
+  font-weight: 700;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.82);
+}
+
+.event-card__track-placeholder-meta {
+  font-size: 0.95rem;
+  line-height: 1.4;
+  color: rgba(255, 255, 255, 0.68);
 }
 
 .event-card__track-shadow,

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -100,6 +100,7 @@ type TranslationBundle = {
   countdownFinish: (relative: string) => string;
   countdownScheduled: string;
   trackLayoutLabel: (parts: string[]) => string;
+  trackLayoutUnavailable: string;
   languageLabel: string;
   seriesLogoAria: (series: string) => string;
   upcomingEventDescriptorFallback: string;
@@ -150,6 +151,7 @@ const LANGUAGE_DEFINITIONS: Record<LanguageCode, LanguageDefinition> = {
       countdownScheduled: 'По расписанию',
       trackLayoutLabel: parts =>
         parts.length ? `Схема автодрома: ${parts.join(' — ')}` : 'Схема автодрома',
+      trackLayoutUnavailable: 'Схема трассы появится позже',
       languageLabel: 'Язык',
       seriesLogoAria: series => `Логотип ${series}`,
       upcomingEventDescriptorFallback: 'Нет событий',
@@ -190,6 +192,7 @@ const LANGUAGE_DEFINITIONS: Record<LanguageCode, LanguageDefinition> = {
       countdownScheduled: 'On schedule',
       trackLayoutLabel: parts =>
         parts.length ? `Circuit layout: ${parts.join(' — ')}` : 'Circuit layout',
+      trackLayoutUnavailable: 'Layout preview coming soon',
       languageLabel: 'Language',
       seriesLogoAria: series => `${series} logo`,
       upcomingEventDescriptorFallback: 'No events',
@@ -230,6 +233,7 @@ const LANGUAGE_DEFINITIONS: Record<LanguageCode, LanguageDefinition> = {
       countdownScheduled: 'Según lo previsto',
       trackLayoutLabel: parts =>
         parts.length ? `Trazado del circuito: ${parts.join(' — ')}` : 'Trazado del circuito',
+      trackLayoutUnavailable: 'Trazado del circuito disponible pronto',
       languageLabel: 'Idioma',
       seriesLogoAria: series => `Logotipo de ${series}`,
       upcomingEventDescriptorFallback: 'Sin eventos',
@@ -270,6 +274,7 @@ const LANGUAGE_DEFINITIONS: Record<LanguageCode, LanguageDefinition> = {
       countdownScheduled: 'Selon le programme',
       trackLayoutLabel: parts =>
         parts.length ? `Tracé du circuit : ${parts.join(' — ')}` : 'Tracé du circuit',
+      trackLayoutUnavailable: 'Tracé du circuit bientôt disponible',
       languageLabel: 'Langue',
       seriesLogoAria: series => `Logo ${series}`,
       upcomingEventDescriptorFallback: 'Aucun événement',
@@ -310,6 +315,7 @@ const LANGUAGE_DEFINITIONS: Record<LanguageCode, LanguageDefinition> = {
       countdownScheduled: 'Planmäßig',
       trackLayoutLabel: parts =>
         parts.length ? `Streckenlayout: ${parts.join(' — ')}` : 'Streckenlayout',
+      trackLayoutUnavailable: 'Streckenlayout folgt in Kürze',
       languageLabel: 'Sprache',
       seriesLogoAria: series => `${series}-Logo`,
       upcomingEventDescriptorFallback: 'Keine Events',
@@ -350,6 +356,7 @@ const LANGUAGE_DEFINITIONS: Record<LanguageCode, LanguageDefinition> = {
       countdownScheduled: '按计划进行',
       trackLayoutLabel: parts =>
         parts.length ? `赛道布局：${parts.join(' — ')}` : '赛道布局',
+      trackLayoutUnavailable: '赛道布局稍后提供',
       languageLabel: '语言',
       seriesLogoAria: series => `${series} 标志`,
       upcomingEventDescriptorFallback: '暂无赛事',
@@ -852,6 +859,7 @@ export default function Home() {
             )
           );
           const trackLabel = texts.trackLayoutLabel(trackLabelParts);
+          const hasTrack = Boolean(track);
           const sessionLabel = sessionLabels[r.session] ?? r.session;
 
           return (
@@ -891,8 +899,12 @@ export default function Home() {
                   {r.circuit ? <span>{r.circuit}</span> : null}
                   <span>{sessionLabel}</span>
                 </div>
-                {track ? (
-                  <div className="event-card__track">
+                <div
+                  className={`event-card__track${hasTrack ? '' : ' event-card__track--placeholder'}`}
+                  role={hasTrack ? undefined : 'img'}
+                  aria-label={hasTrack ? undefined : trackLabel}
+                >
+                  {hasTrack && track ? (
                     <svg
                       viewBox={track.layout.viewBox}
                       role="img"
@@ -903,8 +915,15 @@ export default function Home() {
                       <path className="event-card__track-outline" d={track.layout.path} />
                       <path className="event-card__track-highlight" d={track.layout.path} />
                     </svg>
-                  </div>
-                ) : null}
+                  ) : (
+                    <div className="event-card__track-placeholder" aria-hidden>
+                      <span className="event-card__track-placeholder-title">{trackLabel}</span>
+                      <span className="event-card__track-placeholder-meta">
+                        {texts.trackLayoutUnavailable}
+                      </span>
+                    </div>
+                  )}
+                </div>
                 <div className="event-card__countdown">
                   <span className="event-card__countdown-dot" aria-hidden />
                   <span>{countdown}</span>


### PR DESCRIPTION
## Summary
- add localized copy for a track-layout-unavailable state across all supported languages
- render a styled placeholder when a circuit layout is missing so cards stay uniform
- introduce CSS for the placeholder variant to fill the track area without dead space

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ca8125eedc8331baa8e11dc4598b42