### PR TITLE
Move timezone and language controls to header

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -167,6 +167,24 @@ button {
   flex-wrap: wrap;
 }
 
+.site-header__controls {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: clamp(10px, 3vw, 18px);
+  flex-wrap: wrap;
+}
+
+.site-header__timezone {
+  display: flex;
+  flex: 0 1 auto;
+  min-width: max-content;
+}
+
+.site-header__language {
+  flex: 0 0 auto;
+}
+
 .site-header__link {
   position: relative;
   font-size: 0.82rem;

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1283,9 +1283,40 @@ export default function Home() {
               {texts.navFaq}
             </a>
           </nav>
-          <a className="site-header__cta" href="#schedule">
-            {texts.heroCta}
-          </a>
+          <div className="site-header__controls">
+            <div className="site-header__timezone">
+              <span className="hero__badge hero__capsule">
+                <span className="hero__badge-text">{texts.heroBadge}</span>
+                <span className="hero__badge-timezone">{timezoneBadgeLabel}</span>
+              </span>
+            </div>
+            <label
+              className="hero__language-control hero__capsule site-header__language"
+              htmlFor="language-select"
+            >
+              <span className="hero__language-caption">{texts.languageLabel}</span>
+              <select
+                id="language-select"
+                className="hero__language-dropdown"
+                value={language}
+                onChange={event => {
+                  const value = event.target.value;
+                  if (isLanguageCode(value)) {
+                    setLanguage(value);
+                  }
+                }}
+              >
+                {LANGUAGE_CODES.map(code => (
+                  <option key={code} value={code}>
+                    {LANGUAGE_DEFINITIONS[code].name}
+                  </option>
+                ))}
+              </select>
+            </label>
+            <a className="site-header__cta" href="#schedule">
+              {texts.heroCta}
+            </a>
+          </div>
         </div>
       </header>
 
@@ -1301,44 +1332,11 @@ export default function Home() {
           }
         >
           <div className="hero__intro">
-          <div className="hero__top-row">
-            <div className="hero__badge-wrapper">
-              <span className="hero__badge hero__capsule">
-                <span className="hero__badge-text">{texts.heroBadge}</span>
-                <span className="hero__badge-timezone">{timezoneBadgeLabel}</span>
-              </span>
-            </div>
-            <div className="hero__language">
-              <label
-                className="hero__language-control hero__capsule"
-                htmlFor="language-select"
-              >
-                <span className="hero__language-caption">{texts.languageLabel}</span>
-                <select
-                  id="language-select"
-                  className="hero__language-dropdown"
-                  value={language}
-                  onChange={event => {
-                    const value = event.target.value;
-                    if (isLanguageCode(value)) {
-                      setLanguage(value);
-                    }
-                  }}
-                >
-                  {LANGUAGE_CODES.map(code => (
-                    <option key={code} value={code}>
-                      {LANGUAGE_DEFINITIONS[code].name}
-                    </option>
-                  ))}
-                </select>
-              </label>
-            </div>
+            <h1 className="hero__title">
+              {texts.heroTitle(SERIES_TITLE || 'F1 / F2 / F3 / MotoGP')}
+            </h1>
+            <p className="hero__subtitle">{texts.heroSubtitle}</p>
           </div>
-          <h1 className="hero__title">
-            {texts.heroTitle(SERIES_TITLE || 'F1 / F2 / F3 / MotoGP')}
-          </h1>
-          <p className="hero__subtitle">{texts.heroSubtitle}</p>
-        </div>
         <div className="hero__layout">
           <div className="hero__column">
             <div className="hero-card">


### PR DESCRIPTION
## Summary
- move the timezone badge and language selector from the hero block into the header menu
- add header layout styles so the new controls align with the existing navigation and CTA

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ca8c15ba24833196f30b33efb95da4