### PR TITLE
Fix event card header overflow on small screens

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1224,6 +1224,7 @@ button {
   align-items: flex-start;
   justify-content: space-between;
   gap: 16px;
+  flex-wrap: wrap;
 }
 
 .event-card__series {
@@ -1261,6 +1262,7 @@ button {
   letter-spacing: 0.1em;
   color: rgba(255, 255, 255, 0.62);
   font-size: 0.78rem;
+  margin-left: auto;
 }
 
 .event-card__time {


### PR DESCRIPTION
## Summary
- allow event card header content to wrap instead of overflowing
- keep the datetime block aligned to the right edge when the row wraps

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68ca95660e34833194067b71b4f3b7cb