### PR TITLE
Rework header language selector

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -175,14 +175,143 @@ button {
   flex-wrap: wrap;
 }
 
-.site-header__timezone {
-  display: flex;
-  flex: 0 1 auto;
+.site-header__meta-group {
+  display: inline-flex;
+  align-items: stretch;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  background: rgba(255, 255, 255, 0.05);
+  backdrop-filter: blur(12px);
+  box-shadow: 0 18px 45px -32px rgba(0, 0, 0, 0.8);
+  overflow: hidden;
+}
+
+.site-header__meta-portion {
+  display: inline-flex;
+  align-items: center;
+  gap: 12px;
+  padding: 12px 20px;
   min-width: max-content;
+  position: relative;
+}
+
+.site-header__meta-portion--timezone {
+  border-right: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.site-header__meta-label {
+  font-size: 0.62rem;
+  letter-spacing: 0.24em;
+  color: rgba(255, 255, 255, 0.6);
+  text-transform: uppercase;
+  font-weight: 700;
+}
+
+.site-header__meta-value,
+.site-header__language-value {
+  font-size: 0.78rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  font-weight: 700;
+  color: rgba(255, 255, 255, 0.88);
 }
 
 .site-header__language {
-  flex: 0 0 auto;
+  position: relative;
+  min-width: max-content;
+}
+
+.site-header__language-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 12px;
+  padding: 0;
+  border: none;
+  background: none;
+  color: inherit;
+  font: inherit;
+  text-transform: inherit;
+  cursor: pointer;
+}
+
+.site-header__language-toggle::after {
+  content: '';
+  width: 8px;
+  height: 8px;
+  border-right: 2px solid currentColor;
+  border-bottom: 2px solid currentColor;
+  transform: translateY(-1px) rotate(45deg);
+  opacity: 0.65;
+  transition: transform 0.25s ease, opacity 0.25s ease;
+  pointer-events: none;
+}
+
+.site-header__language-toggle[aria-expanded='true']::after {
+  transform: translateY(2px) rotate(-135deg);
+  opacity: 0.85;
+}
+
+.site-header__language-toggle:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 3px rgba(255, 255, 255, 0.18);
+  border-radius: 999px;
+}
+
+.site-header__language-menu {
+  position: absolute;
+  top: calc(100% + 10px);
+  right: 0;
+  min-width: clamp(180px, 22vw, 220px);
+  padding: 10px;
+  border-radius: 18px;
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  background: rgba(7, 11, 20, 0.96);
+  backdrop-filter: blur(16px);
+  box-shadow: 0 32px 90px -40px rgba(0, 0, 0, 0.9);
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  z-index: 40;
+}
+
+.site-header__language-option {
+  list-style: none;
+}
+
+.site-header__language-option-button {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  border: none;
+  border-radius: 12px;
+  background: none;
+  color: rgba(255, 255, 255, 0.84);
+  font: inherit;
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  font-weight: 700;
+  padding: 10px 14px;
+  cursor: pointer;
+  transition: background 0.2s ease, color 0.2s ease;
+}
+
+.site-header__language-option-button:hover,
+.site-header__language-option-button:focus-visible {
+  background: rgba(255, 255, 255, 0.08);
+  color: #ffffff;
+  outline: none;
+}
+
+.site-header__language-option-button[data-active='true'] {
+  background: linear-gradient(135deg, rgba(225, 6, 0, 0.18), rgba(0, 144, 255, 0.16));
+  color: #ffffff;
+}
+
+.site-header__language-option-check {
+  font-size: 0.9rem;
+  line-height: 1;
 }
 
 .site-header__link {
@@ -821,66 +950,6 @@ button {
   display: inline-flex;
   align-items: center;
   white-space: nowrap;
-}
-
-.hero__language-control {
-  align-items: center;
-  gap: 18px;
-  cursor: pointer;
-  transition: border-color 0.3s ease, background 0.3s ease, box-shadow 0.3s ease;
-}
-
-.hero__language-control::after {
-  content: '';
-  width: 8px;
-  height: 8px;
-  border-right: 2px solid currentColor;
-  border-bottom: 2px solid currentColor;
-  transform: translateY(-1px) rotate(45deg);
-  opacity: 0.65;
-  pointer-events: none;
-}
-
-.hero__language-control:hover {
-  border-color: rgba(255, 255, 255, 0.26);
-  background: rgba(255, 255, 255, 0.07);
-  box-shadow: 0 18px 45px -32px rgba(0, 0, 0, 0.8);
-}
-
-.hero__language-control:focus-within {
-  border-color: rgba(255, 255, 255, 0.36);
-  box-shadow: 0 0 0 3px rgba(255, 255, 255, 0.14);
-}
-
-.hero__language-caption {
-  font-size: 0.62rem;
-  letter-spacing: 0.24em;
-  color: rgba(255, 255, 255, 0.6);
-  text-transform: uppercase;
-  font-weight: 700;
-}
-
-.hero__language-dropdown {
-  -webkit-appearance: none;
-  appearance: none;
-  border: none;
-  background: none;
-  color: rgba(255, 255, 255, 0.9);
-  font-weight: 700;
-  letter-spacing: 0.14em;
-  text-transform: uppercase;
-  font-size: 0.78rem;
-  padding: 0 18px 0 4px;
-  min-width: 150px;
-  cursor: pointer;
-}
-
-.hero__language-dropdown:focus {
-  outline: none;
-}
-
-.hero__language-dropdown option {
-  color: #0f111a;
 }
 
 .hero__badge-timezone {


### PR DESCRIPTION
## Summary
- group the header timezone badge and language toggle into a single capsule-style control
- replace the native language select with a custom dropdown menu that opens on click anywhere on the language label
- add outside-click and Escape handling plus refreshed styling for the language list options

## Testing
- npm run build


------
https://chatgpt.com/codex/tasks/task_e_68ca94d1c47083319e2693a4e8d7e549