### PR TITLE
Fix language menu visibility

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -183,7 +183,7 @@ button {
   background: rgba(255, 255, 255, 0.05);
   backdrop-filter: blur(12px);
   box-shadow: 0 18px 45px -32px rgba(0, 0, 0, 0.8);
-  overflow: hidden;
+  overflow: visible;
 }
 
 .site-header__meta-portion {


### PR DESCRIPTION
## Summary
- allow the header meta group to overflow so the language menu can be shown outside the pill container

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ca98ec406c8331a21256cfca96e3f0