### PR TITLE
Adjust event card layout

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1345,10 +1345,15 @@ button {
   font-size: 0.85rem;
 }
 
-.event-card__title {
+.event-card__info {
   display: flex;
-  flex-wrap: wrap;
-  gap: 10px;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 8px;
+}
+
+.event-card__title {
+  display: block;
   font-size: clamp(1.05rem, 2.6vw, 1.28rem);
   font-weight: 700;
   line-height: 1.35;
@@ -1367,19 +1372,15 @@ button {
   color: rgba(var(--accent-rgb), 0.95);
 }
 
-.event-card__meta {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 8px 12px;
+.event-card__meta-line {
   font-size: 0.88rem;
   color: rgba(255, 255, 255, 0.68);
   letter-spacing: 0.04em;
 }
 
-.event-card__meta span + span::before {
-  content: '•';
-  margin-right: 8px;
-  color: rgba(255, 255, 255, 0.32);
+.event-card__session {
+  color: rgba(var(--accent-rgb), 0.88);
+  font-weight: 600;
 }
 
 .event-card__track {

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1527,13 +1527,15 @@ export default function Home() {
                         </span>
                       </time>
                     </div>
-                    <div className="event-card__title">
-                      <span>{r.round}</span>
-                      {r.country ? <span className="event-card__country">{r.country}</span> : null}
-                    </div>
-                    <div className="event-card__meta">
-                      {r.circuit ? <span>{r.circuit}</span> : null}
-                      <span>{sessionLabel}</span>
+                    <div className="event-card__info">
+                      <span className="event-card__title">{r.round}</span>
+                      {r.country ? (
+                        <span className="event-card__country">{r.country}</span>
+                      ) : null}
+                      {r.circuit ? (
+                        <span className="event-card__meta-line">{r.circuit}</span>
+                      ) : null}
+                      <span className="event-card__meta-line event-card__session">{sessionLabel}</span>
                     </div>
                     {track ? (
                       <div className="event-card__track">


### PR DESCRIPTION
## Summary
- stack event card details so the grand prix name, country, circuit, and session each render on their own line
- refresh styling for the new stacked layout and highlight the session line with the series accent colour

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ca9afff9788331a5a6c6463ad243be