### PR TITLE
Refine header layout for header controls

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -126,9 +126,24 @@ button {
   margin: 0 auto;
   padding: clamp(16px, 4vw, 28px) clamp(18px, 6vw, 54px);
   display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  gap: clamp(14px, 3.4vw, 24px);
+}
+
+.site-header__row {
+  display: flex;
   align-items: center;
-  gap: clamp(12px, 4vw, 32px);
+  gap: clamp(12px, 3.2vw, 28px);
   flex-wrap: wrap;
+}
+
+.site-header__row--top {
+  justify-content: space-between;
+}
+
+.site-header__row--bottom {
+  justify-content: flex-start;
 }
 
 .site-header__brand {
@@ -161,17 +176,7 @@ button {
   display: flex;
   align-items: center;
   gap: clamp(16px, 4vw, 28px);
-  margin-left: clamp(16px, 8vw, 80px);
-  margin-right: auto;
   flex: 1 1 auto;
-  flex-wrap: wrap;
-}
-
-.site-header__controls {
-  display: flex;
-  align-items: center;
-  justify-content: flex-end;
-  gap: clamp(10px, 3vw, 18px);
   flex-wrap: wrap;
 }
 
@@ -184,6 +189,7 @@ button {
   backdrop-filter: blur(12px);
   box-shadow: 0 18px 45px -32px rgba(0, 0, 0, 0.8);
   overflow: visible;
+  margin-left: auto;
 }
 
 .site-header__meta-portion {
@@ -363,6 +369,7 @@ button {
   text-transform: uppercase;
   box-shadow: 0 24px 60px -32px rgba(225, 6, 0, 0.85);
   transition: transform 0.3s ease, box-shadow 0.3s ease;
+  margin-left: auto;
 }
 
 .site-header__cta:hover,

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1265,24 +1265,13 @@ export default function Home() {
     <div className="site" id="top">
       <header className="site-header">
         <div className="site-header__inner">
-          <a className="site-header__brand" href="#top">
-            <span className="site-header__brand-mark" aria-hidden>
-              🏁
-            </span>
-            <span className="site-header__brand-text">{texts.brandName}</span>
-          </a>
-          <nav className="site-header__nav" aria-label={texts.brandName}>
-            <a className="site-header__link" href="#schedule">
-              {texts.navSchedule}
+          <div className="site-header__row site-header__row--top">
+            <a className="site-header__brand" href="#top">
+              <span className="site-header__brand-mark" aria-hidden>
+                🏁
+              </span>
+              <span className="site-header__brand-text">{texts.brandName}</span>
             </a>
-            <a className="site-header__link" href="#features">
-              {texts.navFeatures}
-            </a>
-            <a className="site-header__link" href="#faq">
-              {texts.navFaq}
-            </a>
-          </nav>
-          <div className="site-header__controls">
             <div className="site-header__meta-group">
               <div className="site-header__meta-portion site-header__meta-portion--timezone">
                 <span className="site-header__meta-label">{texts.heroBadge}</span>
@@ -1342,6 +1331,19 @@ export default function Home() {
                 ) : null}
               </div>
             </div>
+          </div>
+          <div className="site-header__row site-header__row--bottom">
+            <nav className="site-header__nav" aria-label={texts.brandName}>
+              <a className="site-header__link" href="#schedule">
+                {texts.navSchedule}
+              </a>
+              <a className="site-header__link" href="#features">
+                {texts.navFeatures}
+              </a>
+              <a className="site-header__link" href="#faq">
+                {texts.navFaq}
+              </a>
+            </nav>
             <a className="site-header__cta" href="#schedule">
               {texts.heroCta}
             </a>


### PR DESCRIPTION
## Summary
- restructure the site header into dedicated top and bottom rows
- move the timezone and language controls into the top row to align them with the brand
- adjust styling so the navigation and call-to-action occupy the lower row with responsive spacing

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ca9c6446508331bd577e671d80b94d