### PR TITLE
Remove header helper labels

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1274,7 +1274,6 @@ export default function Home() {
             </a>
             <div className="site-header__meta-group">
               <div className="site-header__meta-portion site-header__meta-portion--timezone">
-                <span className="site-header__meta-label">{texts.heroBadge}</span>
                 <span className="site-header__meta-value">{timezoneBadgeLabel}</span>
               </div>
               <div
@@ -1290,7 +1289,6 @@ export default function Home() {
                   aria-controls="language-select-menu"
                   onClick={() => setLanguageMenuOpen(prev => !prev)}
                 >
-                  <span className="site-header__meta-label">{texts.languageLabel}</span>
                   <span className="site-header__language-value">{languageDefinition.name}</span>
                 </button>
                 {isLanguageMenuOpen ? (


### PR DESCRIPTION
## Summary
- remove the timezone badge label copy from the header
- drop the language selector helper label to declutter the control

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68caa6c293c08331943ddab7a16bab17