### PR TITLE
Enhance next start summary layout

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1058,6 +1058,53 @@ button {
   box-shadow: 0 32px 90px -60px rgba(var(--accent-rgb), 0.9);
 }
 
+.hero-card__summary {
+  display: flex;
+  flex-direction: column;
+  gap: clamp(14px, 3vw, 20px);
+}
+
+.hero-card__summary-header {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.hero-card__summary-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.hero-card__tag {
+  display: inline-flex;
+  align-items: center;
+  padding: 6px 14px;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  background: rgba(255, 255, 255, 0.18);
+  color: rgba(255, 255, 255, 0.92);
+}
+
+.hero-card__tag--accent {
+  background: rgba(var(--accent-rgb), 0.3);
+  color: #ffffff;
+}
+
+.hero-card__tag--muted {
+  background: rgba(255, 255, 255, 0.14);
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.hero-card__summary-body {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
 .hero-card__section {
   display: flex;
   flex-direction: column;
@@ -1097,6 +1144,12 @@ button {
   font-size: 0.95rem;
   color: rgba(255, 255, 255, 0.72);
   letter-spacing: 0.02em;
+}
+
+.hero-card__meta--title {
+  font-size: 1.05rem;
+  font-weight: 600;
+  color: #ffffff;
 }
 
 .hero-card__meta--muted {

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1251,6 +1251,23 @@ export default function Home() {
   const nextDescriptor = nextEvent
     ? `${nextEvent.round}${nextEvent.country ? ` • ${nextEvent.country}` : ''}`
     : texts.upcomingEventDescriptorFallback;
+  const nextSessionLabel = nextEvent ? sessionLabels[nextEvent.session] ?? nextEvent.session : null;
+  const nextLocationParts = nextEvent
+    ? [nextEvent.circuit, nextEvent.country]
+        .map(part => part?.trim())
+        .filter((part): part is string => !!part && part.length > 0)
+    : [];
+  const nextLocationLabel =
+    nextLocationParts.length > 0
+      ? nextLocationParts.join(' • ')
+      : nextEvent?.country ?? '';
+  const nextDetailsLabel = nextEvent
+    ? nextLocationLabel.length > 0
+      ? nextLocationLabel
+      : nextDescriptor === nextEvent.round
+        ? ''
+        : nextDescriptor
+    : nextDescriptor;
   const heroSeriesDefinition = nextSeriesDefinition ?? FALLBACK_SERIES_DEFINITION;
   const heroAccentColor = heroSeriesDefinition?.accentColor ?? '#e10600';
   const heroAccentRgb = heroSeriesDefinition?.accentRgb ?? '225, 6, 0';
@@ -1441,16 +1458,32 @@ export default function Home() {
             <div className="hero-card hero-card--summary">
               <span className="hero-card__label">{texts.nextStartLabel}</span>
               {nextEvent && nextLocal ? (
-                <>
-                  <span className="hero-card__value">{nextLocal.toFormat('dd LLL • HH:mm')}</span>
-                  <span className="hero-card__meta">{nextSeriesLabel}</span>
-                  <span className="hero-card__meta hero-card__meta--muted">{nextDescriptor}</span>
+                <div className="hero-card__summary">
+                  <div className="hero-card__summary-header">
+                    <span className="hero-card__value">{nextLocal.toFormat('dd LLL • HH:mm')}</span>
+                    {nextSeriesLabel || nextSessionLabel ? (
+                      <div className="hero-card__summary-tags">
+                        {nextSeriesLabel ? (
+                          <span className="hero-card__tag hero-card__tag--accent">{nextSeriesLabel}</span>
+                        ) : null}
+                        {nextSessionLabel ? (
+                          <span className="hero-card__tag hero-card__tag--muted">{nextSessionLabel}</span>
+                        ) : null}
+                      </div>
+                    ) : null}
+                  </div>
+                  <div className="hero-card__summary-body">
+                    <span className="hero-card__meta hero-card__meta--title">{nextEvent.round}</span>
+                    {nextDetailsLabel ? (
+                      <span className="hero-card__meta hero-card__meta--muted">
+                        {nextDetailsLabel}
+                      </span>
+                    ) : null}
+                  </div>
                   {nextCountdown ? (
-                    <span className="hero-card__meta hero-card__meta--accent">
-                      {nextCountdown}
-                    </span>
+                    <span className="hero-card__meta hero-card__meta--accent">{nextCountdown}</span>
                   ) : null}
-                </>
+                </div>
               ) : (
                 <>
                   <span className="hero-card__value">{texts.noEvents}</span>


### PR DESCRIPTION
## Summary
- add session and location parsing helpers for the upcoming event summary
- redesign the next start hero card to show series and session chips with updated layout styling

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68caa80a9c4c8331a9f6a76f6514154f