### PR TITLE
Align header navigation into a single row

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -135,15 +135,13 @@ button {
   display: flex;
   align-items: center;
   gap: clamp(12px, 3.2vw, 28px);
-  flex-wrap: wrap;
+  flex-wrap: nowrap;
+  width: 100%;
+  min-width: 0;
 }
 
-.site-header__row--top {
+.site-header__row--main {
   justify-content: space-between;
-}
-
-.site-header__row--bottom {
-  justify-content: flex-start;
 }
 
 .site-header__brand {
@@ -175,9 +173,19 @@ button {
 .site-header__nav {
   display: flex;
   align-items: center;
+  justify-content: center;
   gap: clamp(16px, 4vw, 28px);
   flex: 1 1 auto;
-  flex-wrap: wrap;
+  flex-wrap: nowrap;
+  min-width: 0;
+}
+
+.site-header__actions {
+  display: inline-flex;
+  align-items: center;
+  gap: clamp(16px, 4vw, 28px);
+  margin-left: clamp(16px, 4vw, 32px);
+  flex-shrink: 0;
 }
 
 .site-header__meta-group {
@@ -189,7 +197,6 @@ button {
   backdrop-filter: blur(12px);
   box-shadow: 0 18px 45px -32px rgba(0, 0, 0, 0.8);
   overflow: visible;
-  margin-left: auto;
 }
 
 .site-header__meta-portion {
@@ -328,6 +335,7 @@ button {
   font-weight: 700;
   color: rgba(255, 255, 255, 0.72);
   padding: 6px 0;
+  white-space: nowrap;
   transition: color 0.3s ease;
 }
 
@@ -369,7 +377,6 @@ button {
   text-transform: uppercase;
   box-shadow: 0 24px 60px -32px rgba(225, 6, 0, 0.85);
   transition: transform 0.3s ease, box-shadow 0.3s ease;
-  margin-left: auto;
 }
 
 .site-header__cta:hover,

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1265,72 +1265,13 @@ export default function Home() {
     <div className="site" id="top">
       <header className="site-header">
         <div className="site-header__inner">
-          <div className="site-header__row site-header__row--top">
+          <div className="site-header__row site-header__row--main">
             <a className="site-header__brand" href="#top">
               <span className="site-header__brand-mark" aria-hidden>
                 🏁
               </span>
               <span className="site-header__brand-text">{texts.brandName}</span>
             </a>
-            <div className="site-header__meta-group">
-              <div className="site-header__meta-portion site-header__meta-portion--timezone">
-                <span className="site-header__meta-value">{timezoneBadgeLabel}</span>
-              </div>
-              <div
-                className="site-header__meta-portion site-header__language"
-                ref={languageControlRef}
-              >
-                <button
-                  type="button"
-                  id="language-select"
-                  className="site-header__language-toggle"
-                  aria-haspopup="listbox"
-                  aria-expanded={isLanguageMenuOpen}
-                  aria-controls="language-select-menu"
-                  onClick={() => setLanguageMenuOpen(prev => !prev)}
-                >
-                  <span className="site-header__language-value">{languageDefinition.name}</span>
-                </button>
-                {isLanguageMenuOpen ? (
-                  <ul
-                    className="site-header__language-menu"
-                    role="listbox"
-                    id="language-select-menu"
-                    aria-labelledby="language-select"
-                  >
-                    {LANGUAGE_CODES.map(code => {
-                      const definition = LANGUAGE_DEFINITIONS[code];
-                      const isSelected = code === language;
-                      return (
-                        <li
-                          key={code}
-                          className="site-header__language-option"
-                          role="option"
-                          aria-selected={isSelected}
-                        >
-                          <button
-                            type="button"
-                            className="site-header__language-option-button"
-                            data-active={isSelected}
-                            onClick={() => {
-                              setLanguage(code);
-                              setLanguageMenuOpen(false);
-                            }}
-                          >
-                            <span className="site-header__language-option-name">
-                              {definition.name}
-                            </span>
-                            {isSelected && <span className="site-header__language-option-check">✓</span>}
-                          </button>
-                        </li>
-                      );
-                    })}
-                  </ul>
-                ) : null}
-              </div>
-            </div>
-          </div>
-          <div className="site-header__row site-header__row--bottom">
             <nav className="site-header__nav" aria-label={texts.brandName}>
               <a className="site-header__link" href="#schedule">
                 {texts.navSchedule}
@@ -1342,9 +1283,68 @@ export default function Home() {
                 {texts.navFaq}
               </a>
             </nav>
-            <a className="site-header__cta" href="#schedule">
-              {texts.heroCta}
-            </a>
+            <div className="site-header__actions">
+              <div className="site-header__meta-group">
+                <div className="site-header__meta-portion site-header__meta-portion--timezone">
+                  <span className="site-header__meta-value">{timezoneBadgeLabel}</span>
+                </div>
+                <div
+                  className="site-header__meta-portion site-header__language"
+                  ref={languageControlRef}
+                >
+                  <button
+                    type="button"
+                    id="language-select"
+                    className="site-header__language-toggle"
+                    aria-haspopup="listbox"
+                    aria-expanded={isLanguageMenuOpen}
+                    aria-controls="language-select-menu"
+                    onClick={() => setLanguageMenuOpen(prev => !prev)}
+                  >
+                    <span className="site-header__language-value">{languageDefinition.name}</span>
+                  </button>
+                  {isLanguageMenuOpen ? (
+                    <ul
+                      className="site-header__language-menu"
+                      role="listbox"
+                      id="language-select-menu"
+                      aria-labelledby="language-select"
+                    >
+                      {LANGUAGE_CODES.map(code => {
+                        const definition = LANGUAGE_DEFINITIONS[code];
+                        const isSelected = code === language;
+                        return (
+                          <li
+                            key={code}
+                            className="site-header__language-option"
+                            role="option"
+                            aria-selected={isSelected}
+                          >
+                            <button
+                              type="button"
+                              className="site-header__language-option-button"
+                              data-active={isSelected}
+                              onClick={() => {
+                                setLanguage(code);
+                                setLanguageMenuOpen(false);
+                              }}
+                            >
+                              <span className="site-header__language-option-name">
+                                {definition.name}
+                              </span>
+                              {isSelected && <span className="site-header__language-option-check">✓</span>}
+                            </button>
+                          </li>
+                        );
+                      })}
+                    </ul>
+                  ) : null}
+                </div>
+              </div>
+              <a className="site-header__cta" href="#schedule">
+                {texts.heroCta}
+              </a>
+            </div>
           </div>
         </div>
       </header>


### PR DESCRIPTION
## Summary
- restructure the site header markup so the brand, navigation, and controls live in a single flex row
- adjust header styling to keep the navigation links on one line and align the timezone, language, and CTA cluster

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68caa834a18883319fc3725060c5c90c