### PR TITLE
Fix header layout overlap for long language labels

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -135,7 +135,7 @@ button {
   display: flex;
   align-items: center;
   gap: clamp(12px, 3.2vw, 28px);
-  flex-wrap: nowrap;
+  flex-wrap: wrap;
   width: 100%;
   min-width: 0;
 }
@@ -187,6 +187,9 @@ button {
   margin-left: clamp(16px, 4vw, 32px);
   flex: 0 1 auto;
   min-width: 0;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  row-gap: clamp(12px, 3.2vw, 20px);
 }
 
 .site-header__meta-group {


### PR DESCRIPTION
## Summary
- allow the header row to wrap so elements no longer overlap when labels grow
- let the actions area wrap and right-align, adding vertical spacing for stacked controls

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68caf30287588331abeebd6ee1ca9a00