### PR TITLE
Remove UTC offset from timezone badge

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -416,9 +416,7 @@ export default function Home() {
 
   const nowLocal = DateTime.local().setZone(userTz).setLocale(locale);
   const timezoneOffset = nowLocal.toFormat('ZZ');
-  const timezoneBadgeLabel = userTz?.trim().length
-    ? `${userTz} (UTC${timezoneOffset})`
-    : `UTC${timezoneOffset}`;
+  const timezoneBadgeLabel = userTz?.trim().length ? userTz : `UTC${timezoneOffset}`;
   const activeSeries = (Object.entries(visibleSeries) as [SeriesId, boolean][])
     .filter(([, active]) => active)
     .map(([series]) => series);


### PR DESCRIPTION
## Summary
- stop appending the UTC offset to the timezone badge label so it shows only the zone name

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cb02a2eb2c8331b6350dcb2fb81878