### PR TITLE
Remove timezone badge from header

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -219,12 +219,6 @@ button {
   flex: 0 1 auto;
 }
 
-.site-header__meta-portion--timezone {
-  border-right: 1px solid rgba(255, 255, 255, 0.08);
-  flex: 1 1 auto;
-  min-width: 0;
-}
-
 .site-header__meta-label {
   font-size: 0.62rem;
   letter-spacing: 0.24em;

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -452,8 +452,6 @@ export default function Home() {
   }, [rows, visibleSeries, hours]);
 
   const nowLocal = DateTime.local().setZone(userTz).setLocale(locale);
-  const timezoneOffset = nowLocal.toFormat('ZZ');
-  const timezoneBadgeLabel = userTz?.trim().length ? userTz : `UTC${timezoneOffset}`;
   const activeSeries = (Object.entries(visibleSeries) as [SeriesId, boolean][])
     .filter(([, active]) => active)
     .map(([series]) => series);
@@ -530,9 +528,6 @@ export default function Home() {
             </nav>
             <div className="site-header__actions">
               <div className="site-header__meta-group">
-                <div className="site-header__meta-portion site-header__meta-portion--timezone">
-                  <span className="site-header__meta-value">{timezoneBadgeLabel}</span>
-                </div>
                 <div
                   className="site-header__meta-portion site-header__language"
                   ref={languageControlRef}


### PR DESCRIPTION
## Summary
- remove the timezone badge from the site header and stop deriving the timezone label
- clean up the unused header styling that supported the timezone badge

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cb0b10f1988331bb950ac20a1bc7f5