### PR TITLE
Fix anchor scroll offset beneath sticky header

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -11,6 +11,10 @@
   -moz-osx-font-smoothing: grayscale;
 }
 
+html {
+  scroll-padding-top: var(--site-header-offset, 120px);
+}
+
 *, *::before, *::after {
   box-sizing: border-box;
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -329,6 +329,7 @@ export default function Home() {
   const [userTz, setUserTz] = useState<string>('UTC');
   const [language, setLanguage] = useState<LanguageCode>(DEFAULT_LANGUAGE);
   const [isLanguageMenuOpen, setLanguageMenuOpen] = useState(false);
+  const headerRef = useRef<HTMLElement | null>(null);
   const languageControlRef = useRef<HTMLDivElement | null>(null);
 
   useEffect(() => {
@@ -378,6 +379,50 @@ export default function Home() {
     document.addEventListener('pointerdown', handlePointerDown);
     return () => {
       document.removeEventListener('pointerdown', handlePointerDown);
+    };
+  }, []);
+
+  useEffect(() => {
+    if (typeof document === 'undefined') {
+      return;
+    }
+
+    const header = headerRef.current;
+    if (!header) {
+      return;
+    }
+
+    const root = document.documentElement;
+    const resizeTarget = document.defaultView as unknown as {
+      addEventListener: (type: 'resize', listener: () => void) => void;
+      removeEventListener: (type: 'resize', listener: () => void) => void;
+    } | null;
+
+    const updateOffset = () => {
+      const height = header.getBoundingClientRect().height;
+      const offset = Math.ceil(height + 24);
+      root.style.setProperty('--site-header-offset', `${offset}px`);
+    };
+
+    updateOffset();
+
+    if (typeof ResizeObserver !== 'undefined') {
+      const observer = new ResizeObserver(() => {
+        updateOffset();
+      });
+      observer.observe(header);
+      return () => {
+        observer.disconnect();
+      };
+    }
+
+    if (!resizeTarget) {
+      return;
+    }
+
+    resizeTarget.addEventListener('resize', updateOffset);
+    return () => {
+      resizeTarget.removeEventListener('resize', updateOffset);
     };
   }, []);
 
@@ -474,7 +519,7 @@ export default function Home() {
 
   return (
     <div className="site" id="top">
-      <header className="site-header">
+      <header className="site-header" ref={headerRef}>
         <div className="site-header__inner">
           <div className="site-header__row site-header__row--main">
             <a className="site-header__brand" href="#top">


### PR DESCRIPTION
## Summary
- add document scroll padding that uses a CSS variable to offset the sticky header
- measure the header height on the client and update the offset dynamically for reliable anchor alignment
- ensure the resize listener uses the document's default view fallback so Next.js type checks pass during builds

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cb0739fdb48331a3057ed3e056433a