### PR TITLE
Reorder header CTA and language selector

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -537,6 +537,9 @@ export default function Home() {
               </a>
             </nav>
             <div className="site-header__actions">
+              <a className="site-header__cta" href="#schedule">
+                {texts.heroCta}
+              </a>
               <div className="site-header__meta-group">
                 <div
                   className="site-header__meta-portion site-header__language"
@@ -591,9 +594,6 @@ export default function Home() {
                   ) : null}
                 </div>
               </div>
-              <a className="site-header__cta" href="#schedule">
-                {texts.heroCta}
-              </a>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- swap the header schedule CTA to appear before the language picker

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cb1011626c8331a3e139ae1b6da92a