### PR TITLE
feat: refresh favicon design

### DIFF
--- a/public/favicon.svg
+++ b/public/favicon.svg
@@ -1,5 +1,21 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
-  <rect width="64" height="64" rx="12" fill="#d32f2f"/>
-  <path fill="#ffffff" d="M15 20h10l-1.5 4h-6.6L15 20zm13 0h10l-1.5 4h-6.6L28 20zm-13 9h10l-1.5 4h-6.6L15 29zm13 0h10l-1.5 4h-6.6L28 29zm13-9h10l-1.5 4h-6.6L41 20zm0 9h10l-1.5 4h-6.6L41 29z"/>
-  <path fill="#ffffff" d="M18 43h28l-2 6H16l2-6z"/>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none">
+  <defs>
+    <linearGradient id="bg" x1="8" y1="8" x2="56" y2="56" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#11131A"/>
+      <stop offset="1" stop-color="#1F2230"/>
+    </linearGradient>
+    <linearGradient id="flare" x1="20" y1="22" x2="44" y2="46" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#FF4B3E"/>
+      <stop offset="1" stop-color="#FF1E56"/>
+    </linearGradient>
+    <filter id="shadow" x="7" y="9" width="50" height="46" color-interpolation-filters="sRGB" filterUnits="userSpaceOnUse">
+      <feDropShadow dx="0" dy="2" stdDeviation="2" flood-color="#000" flood-opacity="0.25"/>
+    </filter>
+  </defs>
+  <rect width="64" height="64" rx="14" fill="url(#bg)"/>
+  <g filter="url(#shadow)">
+    <path d="M18.5 23c4.8-3 10.4-5 16-5 5.1 0 9.1 1.6 11.8 4.6 2.5 2.7 3.7 6.1 3.6 10.4H30.8c-.9 0-1.6.7-1.8 1.5-.8 4.3 2 7 5.7 7 2.6 0 4.7-1.4 5.7-3.8.2-.6.8-1 1.5-1h8.9c-1.4 7.2-7.3 12.3-16 12.3-5.7 0-10.3-1.9-13.4-5.3-3-3.2-4.5-7.5-4.5-12.7 0-3.2.9-6.8 2.5-9.8.5-.9 1.1-1.7 1.6-2.2Z" fill="url(#flare)"/>
+    <path d="M15 38.5c0-4.3 1.3-8.4 3.6-11.9 2.2-3.4 5.3-6.1 9.2-7.9 3.9-1.8 8.3-2.8 13-2.8 2.9 0 5.3.3 7.4 1 .4.1.7.5.6.9l-1.5 7c-.1.4-.5.7-.9.6-2.2-.4-4.1-.6-6.5-.6-4 0-7.4.8-10 2.4-2.7 1.7-4.5 4-5.4 7h13.9c.5 0 .9.4.8.9l-1.5 7.2c-.1.4-.4.7-.9.7H23.8c-.2 0-.4 0-.6-.1-3.5-1.5-5.7-4.5-5.7-8.4Z" fill="#F5F7FF"/>
+  </g>
+  <path d="M14 43.5c0-1.1.9-2 2-2h15.5c1.1 0 2 .9 2 2v1c0 1.1-.9 2-2 2H16c-1.1 0-2-.9-2-2v-1Z" fill="#FFFFFF" fill-opacity="0.12"/>
 </svg>


### PR DESCRIPTION
## Summary
- redesign favicon with a darker gradient background and softened corners
- add stylized racing swoosh and highlight layers for improved legibility

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cb115e9a4c8331a177a27049a76e3d