### PR TITLE
Update site title and favicon metadata

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -15,13 +15,12 @@ const display = Exo_2({
 });
 
 export const metadata: Metadata = {
-  title: 'F1/F2/F3 schedule',
+  title: 'RaceSync',
   description: 'Upcoming qualifying & race times (your time zone)',
   icons: {
-    icon: [
-      { rel: 'icon', url: '/icon.svg', type: 'image/svg+xml' },
-      { rel: 'alternate icon', url: '/favicon.svg', type: 'image/svg+xml' },
-    ],
+    icon: '/favicon.svg',
+    shortcut: '/favicon.svg',
+    apple: '/favicon.svg',
   },
 };
 


### PR DESCRIPTION
## Summary
- update the app metadata title to "RaceSync"
- normalize favicon metadata entries to use the existing SVG icon

## Testing
- npm run lint *(fails: Missing script "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68cb13bfba98833182c81ef053b60ddd