### PR TITLE
Adjust favicon metadata for asset prefix

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -14,13 +14,31 @@ const display = Exo_2({
   variable: '--font-display',
 });
 
+const withAssetPrefix = (path: string) => {
+  const prefix = process.env.NEXT_PUBLIC_ASSET_PREFIX?.trim();
+
+  if (!prefix) {
+    return path;
+  }
+
+  const sanitizedPrefix = prefix.replace(/^\/+|\/+$/g, '');
+
+  if (!sanitizedPrefix) {
+    return path;
+  }
+
+  const normalizedPath = path.replace(/^\/+/, '');
+
+  return `/${sanitizedPrefix}/${normalizedPath}`;
+};
+
 export const metadata: Metadata = {
   title: 'RaceSync',
   description: 'Upcoming qualifying & race times (your time zone)',
   icons: {
-    icon: '/favicon.svg',
-    shortcut: '/favicon.svg',
-    apple: '/favicon.svg',
+    icon: withAssetPrefix('/favicon.svg'),
+    shortcut: withAssetPrefix('/favicon.svg'),
+    apple: withAssetPrefix('/favicon.svg'),
   },
 };
 


### PR DESCRIPTION
## Summary
- add a helper to prefix favicon URLs with the asset prefix exposed by Next.js
- update metadata icons to use the normalized favicon URL

## Testing
- npm run build
- NEXT_PUBLIC_ASSET_PREFIX=/repo npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cb15a8ddfc8331b8a1d11ff0b17e64