### PR TITLE
Remove theme label from toggle button

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -759,7 +759,6 @@ export default function Home() {
                   {themeIcon}
                 </span>
                 <span className="theme-toggle__text">
-                  <span className="theme-toggle__label">{themeCopy.label}</span>
                   <span className="theme-toggle__state">{themeStateLabel}</span>
                 </span>
               </button>


### PR DESCRIPTION
## Summary
- remove the static theme label from the header theme toggle, leaving only the current state

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cbdb241ee883319c03db4c697e31dd