### PR TITLE
Adjust mobile header controls widths

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -2253,29 +2253,34 @@ button {
     gap: 12px;
   }
 
-  .site-header__cta,
-  .theme-toggle,
-  .site-header__meta-group {
+  .site-header__cta {
     width: 100%;
   }
 
+  .theme-toggle {
+    width: auto;
+    align-self: center;
+  }
+
   .site-header__meta-group {
+    width: auto;
     justify-content: center;
+    align-self: center;
   }
 
   .site-header__meta-portion {
     justify-content: center;
-    flex: 1 1 auto;
-    width: 100%;
+    flex: 0 0 auto;
+    width: auto;
   }
 
   .site-header__language {
-    width: 100%;
+    width: auto;
     justify-content: center;
   }
 
   .site-header__language-toggle {
     justify-content: center;
-    width: 100%;
+    width: auto;
   }
 }


### PR DESCRIPTION
## Summary
- stop forcing the theme toggle and language selector to take the full width on narrow screens
- keep the primary CTA full-width while centering the theme toggle and language control in the stacked mobile header layout

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cd24cefe548331871d1fb65950d792