### PR TITLE
Compact header controls for theme and language

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -234,6 +234,7 @@ button {
   text-transform: uppercase;
   font-weight: 700;
   color: rgba(255, 255, 255, 0.88);
+  white-space: nowrap;
 }
 
 .site-header__meta-value {
@@ -433,10 +434,9 @@ button {
 }
 
 .theme-toggle__text {
-  display: flex;
-  flex-direction: column;
-  align-items: flex-start;
-  gap: 2px;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
 }
 
 .theme-toggle__label {
@@ -449,6 +449,7 @@ button {
   font-size: 0.78rem;
   letter-spacing: 0.16em;
   font-weight: 800;
+  white-space: nowrap;
 }
 
 :root[data-theme='light'] {

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -649,7 +649,11 @@ export default function Home() {
   const { texts, periodOptions, sessionLabels, locale } = languageDefinition;
   const themeCopy = texts.theme;
   const themeButtonLabel = theme === 'dark' ? themeCopy.toggleToLight : themeCopy.toggleToDark;
-  const themeStateLabel = theme === 'dark' ? themeCopy.dark : themeCopy.light;
+  const themeStateLabel =
+    theme === 'dark'
+      ? themeCopy.compactDark ?? themeCopy.dark
+      : themeCopy.compactLight ?? themeCopy.light;
+  const languageDisplayName = languageDefinition.shortName || languageDefinition.name;
   const themeIcon = theme === 'dark' ? '🌙' : '☀️';
 
   const filtered = useMemo(() => {
@@ -776,7 +780,7 @@ export default function Home() {
                     aria-controls="language-select-menu"
                     onClick={() => setLanguageMenuOpen(prev => !prev)}
                   >
-                    <span className="site-header__language-value">{languageDefinition.name}</span>
+                    <span className="site-header__language-value">{languageDisplayName}</span>
                   </button>
                   {isLanguageMenuOpen ? (
                     <ul

--- a/lib/language.ts
+++ b/lib/language.ts
@@ -24,6 +24,8 @@ type ThemeCopy = {
   light: string;
   toggleToDark: string;
   toggleToLight: string;
+  compactDark?: string;
+  compactLight?: string;
 };
 
 type FooterLink = {
@@ -106,6 +108,7 @@ type TranslationBundle = {
 export type LanguageDefinition = {
   code: LanguageCode;
   name: string;
+  shortName: string;
   locale: string;
   periodOptions: { label: string; value?: number }[];
   sessionLabels: Record<RaceSession, string>;
@@ -116,6 +119,7 @@ export const LANGUAGE_DEFINITIONS: Record<LanguageCode, LanguageDefinition> = {
   ru: {
     code: 'ru',
     name: 'Русский',
+    shortName: 'RU',
     locale: 'ru',
     periodOptions: [
       { label: '24 часа', value: 24 },
@@ -156,6 +160,8 @@ export const LANGUAGE_DEFINITIONS: Record<LanguageCode, LanguageDefinition> = {
         light: 'Светлая',
         toggleToDark: 'Переключить на тёмную тему',
         toggleToLight: 'Переключить на светлую тему',
+        compactDark: 'Тёмн.',
+        compactLight: 'Светл.',
       },
       seriesLogoAria: series => `Логотип ${series}`,
       upcomingEventDescriptorFallback: 'Нет событий',
@@ -291,6 +297,7 @@ export const LANGUAGE_DEFINITIONS: Record<LanguageCode, LanguageDefinition> = {
   en: {
     code: 'en',
     name: 'English',
+    shortName: 'EN',
     locale: 'en',
     periodOptions: [
       { label: '24 hours', value: 24 },
@@ -331,6 +338,8 @@ export const LANGUAGE_DEFINITIONS: Record<LanguageCode, LanguageDefinition> = {
         light: 'Light',
         toggleToDark: 'Switch to dark theme',
         toggleToLight: 'Switch to light theme',
+        compactDark: 'Dark',
+        compactLight: 'Light',
       },
       seriesLogoAria: series => `${series} logo`,
       upcomingEventDescriptorFallback: 'No events',
@@ -466,6 +475,7 @@ export const LANGUAGE_DEFINITIONS: Record<LanguageCode, LanguageDefinition> = {
   es: {
     code: 'es',
     name: 'Español',
+    shortName: 'ES',
     locale: 'es',
     periodOptions: [
       { label: '24 horas', value: 24 },
@@ -506,6 +516,8 @@ export const LANGUAGE_DEFINITIONS: Record<LanguageCode, LanguageDefinition> = {
         light: 'Clara',
         toggleToDark: 'Cambiar a tema oscuro',
         toggleToLight: 'Cambiar a tema claro',
+        compactDark: 'Osc.',
+        compactLight: 'Clar.',
       },
       seriesLogoAria: series => `Logotipo de ${series}`,
       upcomingEventDescriptorFallback: 'Sin eventos',
@@ -641,6 +653,7 @@ export const LANGUAGE_DEFINITIONS: Record<LanguageCode, LanguageDefinition> = {
   fr: {
     code: 'fr',
     name: 'Français',
+    shortName: 'FR',
     locale: 'fr',
     periodOptions: [
       { label: '24 heures', value: 24 },
@@ -681,6 +694,8 @@ export const LANGUAGE_DEFINITIONS: Record<LanguageCode, LanguageDefinition> = {
         light: 'Clair',
         toggleToDark: 'Activer le thème sombre',
         toggleToLight: 'Activer le thème clair',
+        compactDark: 'Somb.',
+        compactLight: 'Clair',
       },
       seriesLogoAria: series => `Logo ${series}`,
       upcomingEventDescriptorFallback: 'Aucun événement',
@@ -816,6 +831,7 @@ export const LANGUAGE_DEFINITIONS: Record<LanguageCode, LanguageDefinition> = {
   de: {
     code: 'de',
     name: 'Deutsch',
+    shortName: 'DE',
     locale: 'de',
     periodOptions: [
       { label: '24 Stunden', value: 24 },
@@ -856,6 +872,8 @@ export const LANGUAGE_DEFINITIONS: Record<LanguageCode, LanguageDefinition> = {
         light: 'Hell',
         toggleToDark: 'Zur dunklen Ansicht wechseln',
         toggleToLight: 'Zur hellen Ansicht wechseln',
+        compactDark: 'Dunk.',
+        compactLight: 'Hell',
       },
       seriesLogoAria: series => `${series}-Logo`,
       upcomingEventDescriptorFallback: 'Keine Events',
@@ -991,6 +1009,7 @@ export const LANGUAGE_DEFINITIONS: Record<LanguageCode, LanguageDefinition> = {
   zh: {
     code: 'zh',
     name: '中文',
+    shortName: '中文',
     locale: 'zh',
     periodOptions: [
       { label: '24 小时', value: 24 },
@@ -1031,6 +1050,8 @@ export const LANGUAGE_DEFINITIONS: Record<LanguageCode, LanguageDefinition> = {
         light: '浅色',
         toggleToDark: '切换到深色主题',
         toggleToLight: '切换到浅色主题',
+        compactDark: '深色',
+        compactLight: '浅色',
       },
       seriesLogoAria: series => `${series} 标志`,
       upcomingEventDescriptorFallback: '暂无赛事',


### PR DESCRIPTION
## Summary
- show compact labels for the header theme toggle and keep the control to a single line
- display language options with localized abbreviations while keeping the menu list unchanged

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cd32cba2b88331b5e3a302fa636640