### PR TITLE
Refine theme toggle to icon-only sliding design

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -403,19 +403,23 @@ button {
 }
 
 .theme-toggle {
+  --theme-toggle-icon-size: 1.05rem;
+  --theme-toggle-padding: 6px;
   display: inline-flex;
   align-items: center;
-  gap: 12px;
-  padding: 10px 18px;
+  justify-content: center;
+  gap: 0;
+  padding: var(--theme-toggle-padding);
+  width: calc(var(--theme-toggle-icon-size) * 2 + var(--theme-toggle-padding) * 2);
+  min-width: calc(var(--theme-toggle-icon-size) * 2 + var(--theme-toggle-padding) * 2);
   border-radius: 999px;
   border: 1px solid rgba(255, 255, 255, 0.18);
   background: rgba(255, 255, 255, 0.05);
   color: rgba(255, 255, 255, 0.88);
   font: inherit;
-  text-transform: uppercase;
-  letter-spacing: 0.14em;
-  font-weight: 700;
   cursor: pointer;
+  overflow: hidden;
+  box-sizing: border-box;
   transition: transform 0.3s ease, box-shadow 0.3s ease, background 0.3s ease, color 0.3s ease;
 }
 
@@ -428,28 +432,36 @@ button {
   box-shadow: 0 0 0 3px rgba(255, 255, 255, 0.18);
 }
 
-.theme-toggle__icon {
-  font-size: 1.05rem;
-  line-height: 1;
+.theme-toggle__icons {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: calc(var(--theme-toggle-icon-size) * 2);
 }
 
-.theme-toggle__text {
+.theme-toggle__icon {
   display: inline-flex;
   align-items: center;
-  gap: 6px;
+  justify-content: center;
+  width: var(--theme-toggle-icon-size);
+  font-size: var(--theme-toggle-icon-size);
+  line-height: 1;
+  flex-shrink: 0;
+  transition: transform 0.3s ease, opacity 0.3s ease;
+  opacity: 0.45;
 }
 
-.theme-toggle__label {
-  font-size: 0.58rem;
-  letter-spacing: 0.22em;
-  color: rgba(255, 255, 255, 0.6);
+.theme-toggle[data-theme-state='dark'] .theme-toggle__icon--moon,
+.theme-toggle[data-theme-state='light'] .theme-toggle__icon--sun {
+  opacity: 1;
 }
 
-.theme-toggle__state {
-  font-size: 0.78rem;
-  letter-spacing: 0.16em;
-  font-weight: 800;
-  white-space: nowrap;
+.theme-toggle[data-theme-state='light'] .theme-toggle__icon--moon {
+  transform: translateX(calc(var(--theme-toggle-icon-size)));
+}
+
+.theme-toggle[data-theme-state='light'] .theme-toggle__icon--sun {
+  transform: translateX(calc(-1 * var(--theme-toggle-icon-size)));
 }
 
 :root[data-theme='light'] {
@@ -550,10 +562,6 @@ button {
   background: rgba(255, 255, 255, 0.98);
   box-shadow: 0 0 0 3px rgba(18, 22, 37, 0.16);
   color: #0f162c;
-}
-
-:root[data-theme='light'] .theme-toggle__label {
-  color: rgba(18, 22, 37, 0.5);
 }
 
 :root[data-theme='light'] .hero {
@@ -2280,23 +2288,8 @@ button {
   }
 
   .theme-toggle {
-    padding: 8px 14px;
-    gap: 8px;
-    letter-spacing: 0.12em;
-  }
-
-  .theme-toggle__icon {
-    font-size: 0.95rem;
-  }
-
-  .theme-toggle__label {
-    font-size: 0.54rem;
-    letter-spacing: 0.2em;
-  }
-
-  .theme-toggle__state {
-    font-size: 0.68rem;
-    letter-spacing: 0.14em;
+    --theme-toggle-icon-size: 0.95rem;
+    --theme-toggle-padding: 5px;
   }
 
   .site-header__meta-group {

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -649,12 +649,7 @@ export default function Home() {
   const { texts, periodOptions, sessionLabels, locale } = languageDefinition;
   const themeCopy = texts.theme;
   const themeButtonLabel = theme === 'dark' ? themeCopy.toggleToLight : themeCopy.toggleToDark;
-  const themeStateLabel =
-    theme === 'dark'
-      ? themeCopy.compactDark ?? themeCopy.dark
-      : themeCopy.compactLight ?? themeCopy.light;
   const languageDisplayName = languageDefinition.shortName || languageDefinition.name;
-  const themeIcon = theme === 'dark' ? '🌙' : '☀️';
 
   const filtered = useMemo(() => {
     let arr = rows.filter(r => visibleSeries[r.series]);
@@ -757,13 +752,12 @@ export default function Home() {
                 className="theme-toggle"
                 aria-label={themeButtonLabel}
                 aria-pressed={theme === 'light'}
+                data-theme-state={theme}
                 onClick={toggleTheme}
               >
-                <span className="theme-toggle__icon" aria-hidden>
-                  {themeIcon}
-                </span>
-                <span className="theme-toggle__text">
-                  <span className="theme-toggle__state">{themeStateLabel}</span>
+                <span className="theme-toggle__icons" aria-hidden>
+                  <span className="theme-toggle__icon theme-toggle__icon--moon">🌙</span>
+                  <span className="theme-toggle__icon theme-toggle__icon--sun">☀️</span>
                 </span>
               </button>
               <div className="site-header__meta-group">


### PR DESCRIPTION
## Summary
- replace the header theme toggle text with a dual-icon control that keeps only the sun and moon symbols
- add styling so the toggle button is sized for two icons and animates the icons sliding left or right when the theme changes
- tweak responsive variables to preserve the compact layout while dropping unused text styles

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cd8c5e66d0833194253592c2e7fb26