### PR TITLE
Hide events two hours after start

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -655,7 +655,7 @@ export default function Home() {
     let arr = rows.filter(r => visibleSeries[r.series]);
     const now = DateTime.utc();
     const limit = hours && hours > 0 ? hours : 24 * 30; // default 30 days
-    const from = now.minus({ hours: 24 });
+    const from = now.minus({ hours: 2 });
     const to = now.plus({ hours: limit });
     arr = arr.filter(r => {
       const dt = DateTime.fromISO(r.startsAtUtc, { zone: 'utc' });


### PR DESCRIPTION
## Summary
- limit the displayed schedule to events that start no earlier than two hours before the current time, hiding completed sessions sooner

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ce66cb283883319ba211ae5a600a12