### PR TITLE
Display minute countdown for events within two hours

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -96,7 +96,7 @@ function buildRelativeLabel(target: DateTime, base: DateTime, locale: string) {
   const diffInHours = Math.abs(target.diff(base, 'hours').hours);
   const options = { base, locale, style: 'long' } as const;
 
-  if (diffInHours < 1) {
+  if (diffInHours < 2) {
     return target.toRelative({ ...options, unit: 'minutes' });
   }
 


### PR DESCRIPTION
## Summary
- adjust relative time formatting to use minute granularity when events are within two hours

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ce7ca2d4948331be11b1bdb3a60653