### PR TITLE
Add visual status states for live and finished sessions

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -790,8 +790,32 @@ button {
   box-shadow: 0 20px 50px -36px rgba(var(--accent-rgb), 0.35);
 }
 
+:root[data-theme='light'] .event-card__countdown--live {
+  background: rgba(0, 158, 105, 0.12);
+  border-color: rgba(0, 158, 105, 0.38);
+  color: #0c5b3b;
+  box-shadow: 0 20px 50px -36px rgba(0, 158, 105, 0.32);
+}
+
+:root[data-theme='light'] .event-card__countdown--finished {
+  background: rgba(18, 24, 35, 0.08);
+  border-color: rgba(18, 24, 35, 0.18);
+  color: rgba(18, 24, 35, 0.6);
+  box-shadow: none;
+}
+
 :root[data-theme='light'] .event-card__countdown-dot {
   box-shadow: 0 0 0 6px rgba(var(--accent-rgb), 0.2);
+}
+
+:root[data-theme='light'] .event-card__countdown--live .event-card__countdown-dot {
+  background: rgba(0, 158, 105, 0.9);
+  box-shadow: 0 0 0 6px rgba(0, 158, 105, 0.2);
+}
+
+:root[data-theme='light'] .event-card__countdown--finished .event-card__countdown-dot {
+  background: rgba(18, 24, 35, 0.35);
+  box-shadow: 0 0 0 6px rgba(18, 24, 35, 0.12);
 }
 
 :root[data-theme='light'] .cta-section__content p {
@@ -2198,12 +2222,36 @@ button {
   box-shadow: 0 20px 50px -36px rgba(var(--accent-rgb), 0.9);
 }
 
+.event-card__countdown--live {
+  border-color: rgba(14, 192, 120, 0.6);
+  background: rgba(14, 192, 120, 0.18);
+  color: #eafff5;
+  box-shadow: 0 20px 50px -36px rgba(14, 192, 120, 0.9);
+}
+
+.event-card__countdown--finished {
+  border-color: rgba(255, 255, 255, 0.16);
+  background: rgba(255, 255, 255, 0.08);
+  color: rgba(255, 255, 255, 0.72);
+  box-shadow: none;
+}
+
 .event-card__countdown-dot {
   width: 8px;
   height: 8px;
   border-radius: 50%;
   background: rgba(var(--accent-rgb), 0.9);
   box-shadow: 0 0 0 6px rgba(var(--accent-rgb), 0.24);
+}
+
+.event-card__countdown--live .event-card__countdown-dot {
+  background: rgba(14, 192, 120, 0.9);
+  box-shadow: 0 0 0 6px rgba(14, 192, 120, 0.24);
+}
+
+.event-card__countdown--finished .event-card__countdown-dot {
+  background: rgba(255, 255, 255, 0.45);
+  box-shadow: 0 0 0 6px rgba(255, 255, 255, 0.12);
 }
 
 .period-button:focus-visible,

--- a/lib/language.ts
+++ b/lib/language.ts
@@ -75,6 +75,7 @@ type TranslationBundle = {
   noEvents: string;
   extendPeriodHint: string;
   countdownStart: (relative: string) => string;
+  countdownLive: (relative: string) => string;
   countdownFinish: (relative: string) => string;
   countdownScheduled: string;
   trackLayoutLabel: (parts: string[]) => string;
@@ -148,6 +149,7 @@ export const LANGUAGE_DEFINITIONS: Record<LanguageCode, LanguageDefinition> = {
       noEvents: 'Нет событий',
       extendPeriodHint: 'Попробуйте расширить период',
       countdownStart: relative => `Старт ${relative}`,
+      countdownLive: relative => (relative ? `Идёт • старт ${relative}` : 'Идёт'),
       countdownFinish: relative => `Финиш ${relative}`,
       countdownScheduled: 'По расписанию',
       trackLayoutLabel: parts =>
@@ -326,6 +328,7 @@ export const LANGUAGE_DEFINITIONS: Record<LanguageCode, LanguageDefinition> = {
       noEvents: 'No events',
       extendPeriodHint: 'Try expanding the window',
       countdownStart: relative => `Starts ${relative}`,
+      countdownLive: relative => (relative ? `Live now • started ${relative}` : 'Live now'),
       countdownFinish: relative => `Finished ${relative}`,
       countdownScheduled: 'On schedule',
       trackLayoutLabel: parts =>
@@ -504,6 +507,7 @@ export const LANGUAGE_DEFINITIONS: Record<LanguageCode, LanguageDefinition> = {
       noEvents: 'Sin eventos',
       extendPeriodHint: 'Intenta ampliar la ventana',
       countdownStart: relative => `Comienza ${relative}`,
+      countdownLive: relative => (relative ? `En vivo • empezó ${relative}` : 'En vivo'),
       countdownFinish: relative => `Terminó ${relative}`,
       countdownScheduled: 'Según lo previsto',
       trackLayoutLabel: parts =>
@@ -682,6 +686,7 @@ export const LANGUAGE_DEFINITIONS: Record<LanguageCode, LanguageDefinition> = {
       noEvents: 'Aucun événement',
       extendPeriodHint: 'Essayez d’élargir la fenêtre',
       countdownStart: relative => `Commence ${relative}`,
+      countdownLive: relative => (relative ? `En direct • départ ${relative}` : 'En direct'),
       countdownFinish: relative => `Terminé ${relative}`,
       countdownScheduled: 'Selon le programme',
       trackLayoutLabel: parts =>
@@ -860,6 +865,7 @@ export const LANGUAGE_DEFINITIONS: Record<LanguageCode, LanguageDefinition> = {
       noEvents: 'Keine Events',
       extendPeriodHint: 'Versuche den Zeitraum zu vergrößern',
       countdownStart: relative => `Beginnt ${relative}`,
+      countdownLive: relative => (relative ? `Live • Start ${relative}` : 'Live'),
       countdownFinish: relative => `Beendet ${relative}`,
       countdownScheduled: 'Planmäßig',
       trackLayoutLabel: parts =>
@@ -1038,6 +1044,7 @@ export const LANGUAGE_DEFINITIONS: Record<LanguageCode, LanguageDefinition> = {
       noEvents: '暂无赛事',
       extendPeriodHint: '试着延长查看窗口',
       countdownStart: relative => `将于 ${relative} 开始`,
+      countdownLive: relative => (relative ? `正在进行 • 开始于 ${relative}` : '正在进行'),
       countdownFinish: relative => `已于 ${relative} 结束`,
       countdownScheduled: '按计划进行',
       trackLayoutLabel: parts =>

--- a/tests/localization.test.ts
+++ b/tests/localization.test.ts
@@ -52,6 +52,7 @@ describe('localization configuration', () => {
         expect(texts.noEvents.trim().length).toBeGreaterThan(0);
         expect(texts.extendPeriodHint.trim().length).toBeGreaterThan(0);
         expect(texts.countdownStart('через 5 минут').trim().length).toBeGreaterThan(0);
+        expect(texts.countdownLive('5 минут назад').trim().length).toBeGreaterThan(0);
         expect(texts.countdownFinish('через 5 минут').trim().length).toBeGreaterThan(0);
         expect(texts.countdownScheduled.trim().length).toBeGreaterThan(0);
         expect(texts.trackLayoutLabel(['Circuit', 'Round']).trim().length).toBeGreaterThan(0);


### PR DESCRIPTION
## Summary
- parse schedule end times so session status can be derived at render time
- add live and finished countdown messaging with localized strings and styles
- cover the new localization string with existing Vitest suite

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68ce7cbc9d6c8331a4e7cd0b16f441f8