### PR TITLE
Format upcoming countdown under two hours as hh:mm

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -109,10 +109,18 @@ function parseIcsDateTime(raw: string | undefined, tzHint?: string) {
   return null;
 }
 
-function buildRelativeLabel(target: DateTime, base: DateTime, locale: string) {
+export function buildRelativeLabel(target: DateTime, base: DateTime, locale: string) {
   if (!target.isValid || !base.isValid) return null;
 
-  const diffInHours = Math.abs(target.diff(base, 'hours').hours);
+  const diffInSeconds = target.diff(base, 'seconds').seconds;
+  if (diffInSeconds > 0 && diffInSeconds < 2 * 60 * 60) {
+    const totalSeconds = Math.floor(diffInSeconds);
+    const hours = Math.floor(totalSeconds / 3600);
+    const minutes = Math.floor((totalSeconds % 3600) / 60);
+    return `${hours.toString().padStart(2, '0')}:${minutes.toString().padStart(2, '0')}`;
+  }
+
+  const diffInHours = Math.abs(diffInSeconds) / 3600;
   const options = { base, locale, style: 'long' } as const;
 
   if (diffInHours < 2) {

--- a/tests/time-format.test.ts
+++ b/tests/time-format.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+import { DateTime } from 'luxon';
+
+import { buildRelativeLabel } from '../app/page';
+
+describe('buildRelativeLabel', () => {
+  it('formats upcoming events within two hours as hh:mm', () => {
+    const base = DateTime.fromISO('2024-06-01T10:00:00Z');
+    const target = base.plus({ hours: 1, minutes: 5, seconds: 20 });
+
+    expect(buildRelativeLabel(target, base, 'en')).toBe('01:05');
+  });
+
+  it('uses relative hours for events farther in the future', () => {
+    const base = DateTime.fromISO('2024-06-01T10:00:00Z');
+    const target = base.plus({ hours: 3 });
+
+    expect(buildRelativeLabel(target, base, 'en')).toBe('in 3 hours');
+  });
+
+  it('keeps relative minutes for recent past events', () => {
+    const base = DateTime.fromISO('2024-06-01T10:00:00Z');
+    const target = base.minus({ minutes: 90 });
+
+    expect(buildRelativeLabel(target, base, 'en')).toBe('90 minutes ago');
+  });
+});


### PR DESCRIPTION
## Summary
- format short upcoming countdowns as an hh:mm string
- export the relative label helper for testing
- add unit tests covering the new countdown formatting behavior

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ce80f245808331bfd666340b50b823