### PR TITLE
Fix buildRelativeLabel export for Next.js page compliance

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -10,6 +10,7 @@ import {
   type RaceSession,
   isLanguageCode,
 } from '../lib/language';
+import { buildRelativeLabel } from '../lib/relative-time';
 import { getTrackLayout } from '../lib/track-layouts';
 
 type SeriesDefinition = {
@@ -107,31 +108,6 @@ function parseIcsDateTime(raw: string | undefined, tzHint?: string) {
   }
 
   return null;
-}
-
-export function buildRelativeLabel(target: DateTime, base: DateTime, locale: string) {
-  if (!target.isValid || !base.isValid) return null;
-
-  const diffInSeconds = target.diff(base, 'seconds').seconds;
-  if (diffInSeconds > 0 && diffInSeconds < 2 * 60 * 60) {
-    const totalSeconds = Math.floor(diffInSeconds);
-    const hours = Math.floor(totalSeconds / 3600);
-    const minutes = Math.floor((totalSeconds % 3600) / 60);
-    return `${hours.toString().padStart(2, '0')}:${minutes.toString().padStart(2, '0')}`;
-  }
-
-  const diffInHours = Math.abs(diffInSeconds) / 3600;
-  const options = { base, locale, style: 'long' } as const;
-
-  if (diffInHours < 2) {
-    return target.toRelative({ ...options, unit: 'minutes' });
-  }
-
-  if (diffInHours < 48) {
-    return target.toRelative({ ...options, unit: 'hours' });
-  }
-
-  return target.toRelative(options);
 }
 
 const LANGUAGE_STORAGE_KEY = 'schedule-language';

--- a/lib/relative-time.ts
+++ b/lib/relative-time.ts
@@ -1,0 +1,26 @@
+import { DateTime } from 'luxon';
+
+export function buildRelativeLabel(target: DateTime, base: DateTime, locale: string) {
+  if (!target.isValid || !base.isValid) return null;
+
+  const diffInSeconds = target.diff(base, 'seconds').seconds;
+  if (diffInSeconds > 0 && diffInSeconds < 2 * 60 * 60) {
+    const totalSeconds = Math.floor(diffInSeconds);
+    const hours = Math.floor(totalSeconds / 3600);
+    const minutes = Math.floor((totalSeconds % 3600) / 60);
+    return `${hours.toString().padStart(2, '0')}:${minutes.toString().padStart(2, '0')}`;
+  }
+
+  const diffInHours = Math.abs(diffInSeconds) / 3600;
+  const options = { base, locale, style: 'long' } as const;
+
+  if (diffInHours < 2) {
+    return target.toRelative({ ...options, unit: 'minutes' });
+  }
+
+  if (diffInHours < 48) {
+    return target.toRelative({ ...options, unit: 'hours' });
+  }
+
+  return target.toRelative(options);
+}

--- a/tests/time-format.test.ts
+++ b/tests/time-format.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import { DateTime } from 'luxon';
 
-import { buildRelativeLabel } from '../app/page';
+import { buildRelativeLabel } from '../lib/relative-time';
 
 describe('buildRelativeLabel', () => {
   it('formats upcoming events within two hours as hh:mm', () => {


### PR DESCRIPTION
## Summary
- move the buildRelativeLabel helper into a shared lib/relative-time module
- update the app page and related tests to use the shared helper to satisfy Next.js page constraints

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ce840813b48331ad0ec747c47f739e