### PR TITLE
Ensure countdown start text is consistent for clock-style durations

### DIFF
--- a/lib/language.ts
+++ b/lib/language.ts
@@ -116,6 +116,15 @@ export type LanguageDefinition = {
   texts: TranslationBundle;
 };
 
+const CLOCK_RELATIVE_PATTERN = /^\d{1,2}:\d{2}(?::\d{2})?$/;
+
+function formatCountdownStart(relative: string, prefix: string, clockPrefix: string) {
+  const trimmed = relative.trim();
+  if (!trimmed) return prefix;
+  const leading = CLOCK_RELATIVE_PATTERN.test(trimmed) ? clockPrefix : prefix;
+  return `${leading} ${trimmed}`;
+}
+
 export const LANGUAGE_DEFINITIONS: Record<LanguageCode, LanguageDefinition> = {
   ru: {
     code: 'ru',
@@ -148,7 +157,7 @@ export const LANGUAGE_DEFINITIONS: Record<LanguageCode, LanguageDefinition> = {
       nextStartLabel: 'Ближайший старт',
       noEvents: 'Нет событий',
       extendPeriodHint: 'Попробуйте расширить период',
-      countdownStart: relative => `Старт ${relative}`,
+      countdownStart: relative => formatCountdownStart(relative, 'Старт', 'Старт через'),
       countdownLive: relative => (relative ? `Идёт • старт ${relative}` : 'Идёт'),
       countdownFinish: relative => `Финиш ${relative}`,
       countdownScheduled: 'По расписанию',
@@ -327,7 +336,7 @@ export const LANGUAGE_DEFINITIONS: Record<LanguageCode, LanguageDefinition> = {
       nextStartLabel: 'Next session',
       noEvents: 'No events',
       extendPeriodHint: 'Try expanding the window',
-      countdownStart: relative => `Starts ${relative}`,
+      countdownStart: relative => formatCountdownStart(relative, 'Starts', 'Starts in'),
       countdownLive: relative => (relative ? `Live now • started ${relative}` : 'Live now'),
       countdownFinish: relative => `Finished ${relative}`,
       countdownScheduled: 'On schedule',
@@ -506,7 +515,7 @@ export const LANGUAGE_DEFINITIONS: Record<LanguageCode, LanguageDefinition> = {
       nextStartLabel: 'Próxima sesión',
       noEvents: 'Sin eventos',
       extendPeriodHint: 'Intenta ampliar la ventana',
-      countdownStart: relative => `Comienza ${relative}`,
+      countdownStart: relative => formatCountdownStart(relative, 'Comienza', 'Comienza en'),
       countdownLive: relative => (relative ? `En vivo • empezó ${relative}` : 'En vivo'),
       countdownFinish: relative => `Terminó ${relative}`,
       countdownScheduled: 'Según lo previsto',
@@ -685,7 +694,7 @@ export const LANGUAGE_DEFINITIONS: Record<LanguageCode, LanguageDefinition> = {
       nextStartLabel: 'Prochaine session',
       noEvents: 'Aucun événement',
       extendPeriodHint: 'Essayez d’élargir la fenêtre',
-      countdownStart: relative => `Commence ${relative}`,
+      countdownStart: relative => formatCountdownStart(relative, 'Commence', 'Commence dans'),
       countdownLive: relative => (relative ? `En direct • départ ${relative}` : 'En direct'),
       countdownFinish: relative => `Terminé ${relative}`,
       countdownScheduled: 'Selon le programme',
@@ -864,7 +873,7 @@ export const LANGUAGE_DEFINITIONS: Record<LanguageCode, LanguageDefinition> = {
       nextStartLabel: 'Nächste Session',
       noEvents: 'Keine Events',
       extendPeriodHint: 'Versuche den Zeitraum zu vergrößern',
-      countdownStart: relative => `Beginnt ${relative}`,
+      countdownStart: relative => formatCountdownStart(relative, 'Beginnt', 'Beginnt in'),
       countdownLive: relative => (relative ? `Live • Start ${relative}` : 'Live'),
       countdownFinish: relative => `Beendet ${relative}`,
       countdownScheduled: 'Planmäßig',

--- a/tests/time-format.test.ts
+++ b/tests/time-format.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import { DateTime } from 'luxon';
 
+import { LANGUAGE_DEFINITIONS } from '../lib/language';
 import { buildRelativeLabel } from '../lib/relative-time';
 
 describe('buildRelativeLabel', () => {
@@ -23,5 +24,21 @@ describe('buildRelativeLabel', () => {
     const target = base.minus({ minutes: 90 });
 
     expect(buildRelativeLabel(target, base, 'en')).toBe('90 minutes ago');
+  });
+});
+
+describe('countdownStart copy', () => {
+  it('keeps russian phrasing consistent for clock-style durations', () => {
+    const { countdownStart } = LANGUAGE_DEFINITIONS.ru.texts;
+
+    expect(countdownStart('01:17')).toBe('Старт через 01:17');
+    expect(countdownStart('через 2 часа')).toBe('Старт через 2 часа');
+  });
+
+  it('keeps english phrasing consistent for clock-style durations', () => {
+    const { countdownStart } = LANGUAGE_DEFINITIONS.en.texts;
+
+    expect(countdownStart('01:17')).toBe('Starts in 01:17');
+    expect(countdownStart('in 3 hours')).toBe('Starts in 3 hours');
   });
 });


### PR DESCRIPTION
## Summary
- ensure countdown start translations add the appropriate prefix when the relative label is rendered in clock format
- add regression tests covering the Russian and English countdown phrasing

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ce8587d7f48331af237f578d37d574