### PR TITLE
Ensure site header brand stays left-aligned on medium screens

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1496,7 +1496,7 @@ button {
   }
 
   .site-header__brand {
-    order: 1;
+    order: 0;
   }
 }
 


### PR DESCRIPTION
## Summary
- keep the brand block ordered first within the header layout for medium-width viewports so it stays on the left side

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ce86098c0883319a8bc04aa4c574ea