### PR TITLE
Refactor schedule page into modular utilities

### DIFF
--- a/app/hooks/useThemePreference.ts
+++ b/app/hooks/useThemePreference.ts
@@ -1,0 +1,90 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+
+import { isTheme, SYSTEM_THEME_QUERY, THEME_STORAGE_KEY, type Theme } from '../../lib/theme';
+
+export function useThemePreference() {
+  const [theme, setTheme] = useState<Theme>('dark');
+  const [isInitialized, setInitialized] = useState(false);
+
+  const applyThemeToDocument = useCallback((next: Theme) => {
+    if (typeof document === 'undefined') return;
+    const root = document.documentElement;
+    root.dataset.theme = next;
+    root.style.colorScheme = next;
+  }, []);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+
+    const media = window.matchMedia(SYSTEM_THEME_QUERY);
+    const stored = window.localStorage.getItem(THEME_STORAGE_KEY);
+    let initial: Theme = 'dark';
+    let hasStoredPreference = false;
+
+    if (isTheme(stored)) {
+      initial = stored;
+      hasStoredPreference = true;
+    } else if (media.matches) {
+      initial = 'light';
+    }
+
+    applyThemeToDocument(initial);
+    setTheme(initial);
+    setInitialized(true);
+
+    if (hasStoredPreference) {
+      return;
+    }
+
+    const handleMediaChange = (event: MediaQueryListEvent) => {
+      const currentPreference = window.localStorage.getItem(THEME_STORAGE_KEY);
+      if (isTheme(currentPreference)) {
+        return;
+      }
+      setTheme(event.matches ? 'light' : 'dark');
+    };
+
+    media.addEventListener('change', handleMediaChange);
+    return () => {
+      media.removeEventListener('change', handleMediaChange);
+    };
+  }, [applyThemeToDocument]);
+
+  useEffect(() => {
+    if (!isInitialized) return;
+    applyThemeToDocument(theme);
+  }, [applyThemeToDocument, isInitialized, theme]);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+
+    const handleStorage = (event: StorageEvent) => {
+      if (event.key !== THEME_STORAGE_KEY) return;
+      if (isTheme(event.newValue)) {
+        setTheme(event.newValue);
+      } else if (event.newValue === null) {
+        const prefersLight = window.matchMedia(SYSTEM_THEME_QUERY).matches;
+        setTheme(prefersLight ? 'light' : 'dark');
+      }
+    };
+
+    window.addEventListener('storage', handleStorage);
+    return () => {
+      window.removeEventListener('storage', handleStorage);
+    };
+  }, []);
+
+  const toggleTheme = useCallback(() => {
+    setTheme(prev => {
+      const next = prev === 'dark' ? 'light' : 'dark';
+      if (typeof window !== 'undefined') {
+        window.localStorage.setItem(THEME_STORAGE_KEY, next);
+      }
+      return next;
+    });
+  }, []);
+
+  return { theme, toggleTheme };
+}

--- a/lib/ics.ts
+++ b/lib/ics.ts
@@ -1,0 +1,218 @@
+import { DateTime } from 'luxon';
+
+import type { RaceSession } from './language';
+import { DEFAULT_SERIES_ID, isSeriesId, type SeriesId } from './series';
+
+export type ScheduleEvent = {
+  series: SeriesId;
+  round: string;
+  country?: string;
+  circuit?: string;
+  session: RaceSession;
+  startsAtUtc: string;
+  endsAtUtc?: string;
+};
+
+const ICS_DATE_FORMATS: Array<[string, { zone: string }]> = [
+  ["yyyyMMdd'T'HHmmss'Z'", { zone: 'utc' }],
+  ["yyyyMMdd'T'HHmmss", { zone: 'utc' }],
+  ['yyyyMMdd', { zone: 'utc' }],
+];
+
+function parseIcsDateTime(raw: string | undefined, tzHint?: string) {
+  if (!raw) return null;
+
+  const normalizedTz = tzHint && tzHint.trim().length > 0 ? tzHint : undefined;
+  const attempts: Array<[string, { zone: string }]> = [
+    ...ICS_DATE_FORMATS.slice(0, 1),
+    ["yyyyMMdd'T'HHmmss", { zone: normalizedTz ?? 'utc' }],
+    ['yyyyMMdd', { zone: normalizedTz ?? 'utc' }],
+  ];
+
+  for (const [format, options] of attempts) {
+    const dt = DateTime.fromFormat(raw, format, options);
+    if (dt.isValid) return dt;
+  }
+
+  return null;
+}
+
+function normalizeSession(raw: string): RaceSession | undefined {
+  const trimmed = raw.trim();
+  if (!trimmed.length) return undefined;
+
+  const lower = trimmed.toLowerCase();
+  const upper = trimmed.toUpperCase();
+
+  if (lower.includes('sprint') || upper === 'SPR') {
+    if (lower.includes('qual')) return 'Qualifying';
+    return 'Sprint';
+  }
+  if (lower.includes('qual') || /^Q\d+$/.test(upper)) return 'Qualifying';
+  if (lower.includes('feature')) return 'Race';
+  if (lower.includes('race') || upper === 'RAC' || lower === 'grand prix' || upper === 'GP') return 'Race';
+  return undefined;
+}
+
+function extractLocationParts(location?: string) {
+  if (!location) return [];
+  const normalized = location.replace(/\\,/g, ',').replace(/\\\\/g, '\\');
+  return normalized
+    .split(',')
+    .map(part => part.trim())
+    .filter(Boolean);
+}
+
+function sanitizeRoundLabel(round: string | undefined, circuit?: string, country?: string) {
+  const trimmed = round?.replace(/\s+/g, ' ').trim();
+  if (trimmed && trimmed.length > 0) return trimmed;
+  if (country) return `${country} MotoGP`;
+  if (circuit) return circuit;
+  return 'MotoGP';
+}
+
+type ParseOptions = {
+  fallbackSeriesId?: SeriesId;
+};
+
+export function parseSchedule(ics: string, options: ParseOptions = {}): ScheduleEvent[] {
+  const lines = ics.split(/\r?\n/);
+  const events: ScheduleEvent[] = [];
+  let current: Record<string, string> = {};
+  const fallbackSeriesId = options.fallbackSeriesId ?? DEFAULT_SERIES_ID;
+
+  for (const line of lines) {
+    if (line === 'BEGIN:VEVENT') {
+      current = {};
+      continue;
+    }
+
+    if (line === 'END:VEVENT') {
+      const summary = current.SUMMARY;
+      const dtstart = current.DTSTART;
+      if (!summary || !dtstart) {
+        current = {};
+        continue;
+      }
+
+      const categories = current.CATEGORIES
+        ? current.CATEGORIES.split(',').map(part => part.trim()).filter(Boolean)
+        : [];
+      const isMotoGpEvent =
+        categories.some(cat => cat.toLowerCase() === 'motogp') || /^MotoGP\b/i.test(summary);
+
+      if (summary.includes('|')) {
+        const parts = summary.split('|').map(part => part.trim());
+        if (parts.length >= 5) {
+          const [seriesRaw, roundRaw, countryRaw, circuitRaw, sessionRaw] = parts;
+          if (isSeriesId(seriesRaw)) {
+            const start = parseIcsDateTime(dtstart, current.DTSTART_TZID);
+            if (start) {
+              const session = normalizeSession(sessionRaw);
+              if (session) {
+                const round = roundRaw.trim();
+                const country = countryRaw.trim();
+                const circuit = circuitRaw.trim();
+                const end = parseIcsDateTime(current.DTEND, current.DTEND_TZID ?? current.DTSTART_TZID);
+
+                events.push({
+                  series: seriesRaw,
+                  round,
+                  country: country.length ? country : undefined,
+                  circuit: circuit.length ? circuit : undefined,
+                  session,
+                  startsAtUtc: start.toUTC().toISO()!,
+                  endsAtUtc: end?.toUTC().toISO() ?? undefined,
+                });
+              }
+            }
+          }
+        }
+      } else if (isMotoGpEvent) {
+        const start = parseIcsDateTime(dtstart, current.DTSTART_TZID);
+        if (start) {
+          const [rawDetails, rawRoundCandidate] = summary.split(/\s+[–-]\s+/);
+          const detailPart = rawDetails ?? summary;
+          const sessionCode = detailPart.replace(/^MotoGP\s*/i, '').trim();
+          const session = normalizeSession(sessionCode);
+          if (session) {
+            const roundCandidate = rawRoundCandidate?.trim() ?? '';
+            const locationParts = extractLocationParts(current.LOCATION);
+            const circuit = locationParts[0];
+            const country = locationParts.length > 1 ? locationParts.slice(1).join(', ') : undefined;
+
+            const descriptionLines = current.DESCRIPTION
+              ? current.DESCRIPTION.split('\\n').map(line => line.trim()).filter(Boolean)
+              : [];
+            let round = roundCandidate;
+            if (!round.length) {
+              const fallbackLine =
+                descriptionLines.find(line => /grand prix/i.test(line)) ?? descriptionLines[0];
+              if (fallbackLine) {
+                round = fallbackLine.replace(/^MotoGP\s*/i, '').replace(/^PT\s+/i, '').trim();
+              } else {
+                round = sanitizeRoundLabel(roundCandidate, circuit, country);
+              }
+            }
+
+            round = sanitizeRoundLabel(round, circuit, country);
+            const series: SeriesId = 'MotoGP';
+            const end = parseIcsDateTime(current.DTEND, current.DTEND_TZID ?? current.DTSTART_TZID);
+
+            events.push({
+              series,
+              round,
+              country: country && country.length ? country : undefined,
+              circuit: circuit && circuit.length ? circuit : undefined,
+              session,
+              startsAtUtc: start.toUTC().toISO()!,
+              endsAtUtc: end?.toUTC().toISO() ?? undefined,
+            });
+          }
+        }
+      } else {
+        const [rawEvent, rawSession] = summary.split(' - ');
+        if (rawEvent && rawSession && fallbackSeriesId) {
+          const session = normalizeSession(rawSession);
+          if (session) {
+            const eventName = rawEvent.replace(/^RN365\s*/, '').trim();
+            const start = parseIcsDateTime(dtstart, current.DTSTART_TZID);
+            if (start) {
+              const circuit = current.LOCATION
+                ?.replace(/\\,/g, ',')
+                .replace(/\\\\/g, '\\');
+              const end = parseIcsDateTime(current.DTEND, current.DTEND_TZID ?? current.DTSTART_TZID);
+
+              events.push({
+                series: fallbackSeriesId,
+                round: eventName,
+                circuit,
+                session,
+                startsAtUtc: start.toUTC().toISO()!,
+                endsAtUtc: end?.toUTC().toISO() ?? undefined,
+              });
+            }
+          }
+        }
+      }
+
+      current = {};
+      continue;
+    }
+
+    const [rawKey, value] = line.split(':', 2);
+    if (!rawKey || !value) continue;
+    const [key, ...params] = rawKey.split(';');
+    current[key] = value;
+    if (key === 'DTSTART') {
+      const tzParam = params.find(p => p.startsWith('TZID='));
+      if (tzParam) current.DTSTART_TZID = tzParam.split('=')[1];
+    }
+    if (key === 'DTEND') {
+      const tzParam = params.find(p => p.startsWith('TZID='));
+      if (tzParam) current.DTEND_TZID = tzParam.split('=')[1];
+    }
+  }
+
+  return events;
+}

--- a/lib/preferences.ts
+++ b/lib/preferences.ts
@@ -1,0 +1,3 @@
+export const LANGUAGE_STORAGE_KEY = 'schedule-language';
+export const SERIES_STORAGE_KEY = 'schedule-visible-series';
+export const PERIOD_STORAGE_KEY = 'schedule-review-period-hours';

--- a/lib/schedule.ts
+++ b/lib/schedule.ts
@@ -1,0 +1,105 @@
+import { DateTime } from 'luxon';
+
+import { buildRelativeLabel } from './relative-time';
+import type { ScheduleEvent } from './ics';
+import type { LanguageCode } from './language';
+import type { SeriesId } from './series';
+
+export type EventStatus = 'upcoming' | 'live' | 'finished';
+
+export type LocalizedScheduleEvent = {
+  event: ScheduleEvent;
+  localStart: DateTime;
+  localEnd: DateTime | null;
+  startRelative: string | null;
+  finishRelative: string | null;
+  status: EventStatus;
+};
+
+type CountdownCopy = {
+  countdownLive: (relative: string) => string;
+  countdownFinish: (relative: string) => string;
+  countdownStart: (relative: string) => string;
+  countdownScheduled: string;
+};
+
+export function filterEventsByVisibility(
+  events: ScheduleEvent[],
+  visibleSeries: Record<SeriesId, boolean>,
+  hours?: number,
+  now: DateTime = DateTime.utc(),
+) {
+  const limit = hours && hours > 0 ? hours : 24 * 30;
+  const from = now.minus({ hours: 2 });
+  const to = now.plus({ hours: limit });
+
+  return events
+    .filter(event => visibleSeries[event.series])
+    .filter(event => {
+      const startUtc = DateTime.fromISO(event.startsAtUtc, { zone: 'utc' });
+      const endUtcRaw = event.endsAtUtc ? DateTime.fromISO(event.endsAtUtc, { zone: 'utc' }) : null;
+      const endUtc = endUtcRaw && endUtcRaw.isValid ? endUtcRaw : null;
+      const startsWithinWindow = startUtc >= from && startUtc <= to;
+      const endsAfterFrom = endUtc ? endUtc >= from : false;
+      const startsBeforeTo = startUtc <= to;
+      return (startsWithinWindow || endsAfterFrom) && startsBeforeTo;
+    })
+    .slice()
+    .sort((a, b) => Date.parse(a.startsAtUtc) - Date.parse(b.startsAtUtc));
+}
+
+export function localizeEvent(
+  event: ScheduleEvent,
+  userTz: string,
+  locale: LanguageCode,
+  nowLocal: DateTime,
+): LocalizedScheduleEvent {
+  const localStart = DateTime.fromISO(event.startsAtUtc, { zone: 'utc' })
+    .setZone(userTz)
+    .setLocale(locale);
+  const endLocalRaw = event.endsAtUtc
+    ? DateTime.fromISO(event.endsAtUtc, { zone: 'utc' }).setZone(userTz)
+    : null;
+  const localEnd = endLocalRaw && endLocalRaw.isValid ? endLocalRaw.setLocale(locale) : null;
+  const startRelative = buildRelativeLabel(localStart, nowLocal, locale);
+  const finishRelative = localEnd ? buildRelativeLabel(localEnd, nowLocal, locale) : null;
+
+  let status: EventStatus = 'upcoming';
+  if (localEnd && localEnd <= nowLocal) {
+    status = 'finished';
+  } else if (localStart <= nowLocal) {
+    status = 'live';
+  }
+
+  return {
+    event,
+    localStart,
+    localEnd,
+    startRelative,
+    finishRelative,
+    status,
+  };
+}
+
+export function buildCountdownLabel(
+  status: EventStatus,
+  startRelative: string | null,
+  finishRelative: string | null,
+  copy: CountdownCopy,
+) {
+  if (status === 'live') {
+    return copy.countdownLive(startRelative ?? '');
+  }
+
+  if (status === 'finished') {
+    if (finishRelative) {
+      return copy.countdownFinish(finishRelative);
+    }
+    if (startRelative) {
+      return copy.countdownFinish(startRelative);
+    }
+    return copy.countdownScheduled;
+  }
+
+  return startRelative ? copy.countdownStart(startRelative) : copy.countdownScheduled;
+}

--- a/lib/series.ts
+++ b/lib/series.ts
@@ -1,0 +1,55 @@
+import type { RaceSession } from './language';
+
+type SeriesDefinitionBase = {
+  label: string;
+  accentColor: string;
+  accentRgb: string;
+};
+
+export type SeriesDefinition = SeriesDefinitionBase & {
+  sessions?: Partial<Record<RaceSession, string>>;
+};
+
+export const SERIES_DEFINITIONS = {
+  F1: {
+    label: 'F1',
+    accentColor: '#e10600',
+    accentRgb: '225, 6, 0',
+  },
+  F2: {
+    label: 'F2',
+    accentColor: '#0090ff',
+    accentRgb: '0, 144, 255',
+  },
+  F3: {
+    label: 'F3',
+    accentColor: '#ff6f00',
+    accentRgb: '255, 111, 0',
+  },
+  MotoGP: {
+    label: 'MotoGP',
+    accentColor: '#ff0050',
+    accentRgb: '255, 0, 80',
+  },
+} as const satisfies Record<string, SeriesDefinition>;
+
+export type SeriesId = keyof typeof SERIES_DEFINITIONS;
+
+export const SERIES_IDS = Object.keys(SERIES_DEFINITIONS) as SeriesId[];
+
+export const DEFAULT_SERIES_ID: SeriesId | undefined = SERIES_IDS[0];
+
+export const FALLBACK_SERIES_DEFINITION = DEFAULT_SERIES_ID
+  ? SERIES_DEFINITIONS[DEFAULT_SERIES_ID]
+  : undefined;
+
+export function isSeriesId(value: string): value is SeriesId {
+  return Object.prototype.hasOwnProperty.call(SERIES_DEFINITIONS, value);
+}
+
+export function buildSeriesVisibility(value: boolean): Record<SeriesId, boolean> {
+  return SERIES_IDS.reduce<Record<SeriesId, boolean>>((acc, series) => {
+    acc[series] = value;
+    return acc;
+  }, {} as Record<SeriesId, boolean>);
+}

--- a/lib/theme.ts
+++ b/lib/theme.ts
@@ -1,0 +1,8 @@
+export type Theme = 'dark' | 'light';
+
+export const THEME_STORAGE_KEY = 'schedule-theme';
+export const SYSTEM_THEME_QUERY = '(prefers-color-scheme: light)';
+
+export function isTheme(value: unknown): value is Theme {
+  return value === 'dark' || value === 'light';
+}


### PR DESCRIPTION
## Summary
- extract series definitions, ICS parsing, and scheduling utilities into dedicated modules
- introduce a reusable theme preference hook and storage key constants
- simplify the home page by reusing shared helpers and localized event metadata

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68ce909bf1ec8331b0f587c9f19bf6a6