### PR TITLE
Adjust header layout to two-line structure

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -145,10 +145,16 @@ button {
 }
 
 .site-header__row--main {
-  justify-content: space-between;
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  grid-template-areas: 'brand nav actions';
+  align-items: center;
+  column-gap: clamp(14px, 3.2vw, 24px);
+  row-gap: clamp(10px, 2.6vw, 18px);
 }
 
 .site-header__brand {
+  grid-area: brand;
   display: inline-flex;
   align-items: center;
   gap: 12px;
@@ -175,6 +181,7 @@ button {
 }
 
 .site-header__nav {
+  grid-area: nav;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -185,15 +192,17 @@ button {
 }
 
 .site-header__actions {
+  grid-area: actions;
   display: inline-flex;
   align-items: center;
   gap: clamp(14px, 3.2vw, 24px);
-  margin-left: clamp(12px, 3.4vw, 28px);
+  margin-left: 0;
   flex: 0 1 auto;
   min-width: 0;
   flex-wrap: wrap;
   justify-content: flex-end;
   row-gap: clamp(10px, 2.6vw, 18px);
+  justify-self: end;
 }
 
 .site-header__meta-group {
@@ -1484,19 +1493,20 @@ button {
     justify-content: space-between;
   }
 
+  .site-header__row--main {
+    grid-template-columns: 1fr auto;
+    grid-template-areas:
+      'brand actions'
+      'nav nav';
+  }
+
   .site-header__nav {
-    order: 3;
-    width: 100%;
-    margin: 12px 0 0;
     justify-content: flex-start;
+    margin: 0;
   }
 
-  .site-header__cta {
-    order: 2;
-  }
-
-  .site-header__brand {
-    order: 0;
+  .site-header__actions {
+    justify-self: end;
   }
 }
 


### PR DESCRIPTION
## Summary
- refactor the header row to use a CSS grid layout so the brand, navigation, and actions align predictably
- update responsive rules to ensure the top menu collapses into two rows on smaller screens while keeping large-screen spacing consistent

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cea281ce7c83318f6de00c493e65b8