### PR TITLE
Show series logos on event cards

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -2041,6 +2041,14 @@ button {
   gap: 12px;
 }
 
+.event-card__series-logo {
+  display: block;
+  height: clamp(16px, 2.8vw, 22px);
+  width: auto;
+  user-select: none;
+  pointer-events: none;
+}
+
 .event-card__series-pill {
   padding: 6px 14px;
   border-radius: 999px;

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -615,6 +615,16 @@ export default function Home() {
                   <div className="event-card__inner">
                     <div className="event-card__top">
                       <div className="event-card__series">
+                        <img
+                          src={definition.logo.src}
+                          alt=""
+                          width={definition.logo.width}
+                          height={definition.logo.height}
+                          className="event-card__series-logo"
+                          loading="lazy"
+                          aria-hidden="true"
+                          draggable={false}
+                        />
                         <span className="event-card__series-pill">{definition.label}</span>
                       </div>
                       <time className="event-card__datetime" dateTime={isoLocal ?? undefined}>

--- a/lib/series.ts
+++ b/lib/series.ts
@@ -1,9 +1,16 @@
 import type { RaceSession } from './language';
 
+type SeriesLogo = {
+  src: string;
+  width: number;
+  height: number;
+};
+
 type SeriesDefinitionBase = {
   label: string;
   accentColor: string;
   accentRgb: string;
+  logo: SeriesLogo;
 };
 
 export type SeriesDefinition = SeriesDefinitionBase & {
@@ -15,21 +22,41 @@ export const SERIES_DEFINITIONS = {
     label: 'F1',
     accentColor: '#e10600',
     accentRgb: '225, 6, 0',
+    logo: {
+      src: '/logos/f1.svg',
+      width: 120,
+      height: 30,
+    },
   },
   F2: {
     label: 'F2',
     accentColor: '#0090ff',
     accentRgb: '0, 144, 255',
+    logo: {
+      src: '/logos/f2.svg',
+      width: 1000,
+      height: 320,
+    },
   },
   F3: {
     label: 'F3',
     accentColor: '#ff6f00',
     accentRgb: '255, 111, 0',
+    logo: {
+      src: '/logos/f3.svg',
+      width: 1000,
+      height: 320,
+    },
   },
   MotoGP: {
     label: 'MotoGP',
     accentColor: '#ff0050',
     accentRgb: '255, 0, 80',
+    logo: {
+      src: '/logos/motogp.svg',
+      width: 486,
+      height: 266,
+    },
   },
 } as const satisfies Record<string, SeriesDefinition>;
 


### PR DESCRIPTION
## Summary
- add logo metadata to each series definition
- render the series logos inside event cards and style them to fit the layout

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cea2a6bae48331b03e716e4ae80695