### PR TITLE
Adjust header layout to keep two-row menu on small screens

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -145,10 +145,16 @@ button {
 }
 
 .site-header__row--main {
-  justify-content: space-between;
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  grid-template-areas: 'brand nav actions';
+  align-items: center;
+  column-gap: clamp(14px, 3.2vw, 24px);
+  row-gap: clamp(10px, 2.6vw, 18px);
 }
 
 .site-header__brand {
+  grid-area: brand;
   display: inline-flex;
   align-items: center;
   gap: 12px;
@@ -175,6 +181,7 @@ button {
 }
 
 .site-header__nav {
+  grid-area: nav;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -185,15 +192,17 @@ button {
 }
 
 .site-header__actions {
+  grid-area: actions;
   display: inline-flex;
   align-items: center;
   gap: clamp(14px, 3.2vw, 24px);
-  margin-left: clamp(12px, 3.4vw, 28px);
+  margin-left: 0;
   flex: 0 1 auto;
   min-width: 0;
   flex-wrap: wrap;
   justify-content: flex-end;
   row-gap: clamp(10px, 2.6vw, 18px);
+  justify-self: end;
 }
 
 .site-header__meta-group {
@@ -1484,19 +1493,20 @@ button {
     justify-content: space-between;
   }
 
+  .site-header__row--main {
+    grid-template-columns: 1fr auto;
+    grid-template-areas:
+      'brand actions'
+      'nav nav';
+  }
+
   .site-header__nav {
-    order: 3;
-    width: 100%;
-    margin: 12px 0 0;
     justify-content: flex-start;
+    margin: 0;
   }
 
-  .site-header__cta {
-    order: 2;
-  }
-
-  .site-header__brand {
-    order: 0;
+  .site-header__actions {
+    justify-self: end;
   }
 }
 
@@ -2307,12 +2317,12 @@ button {
 
   .site-header__row--main {
     display: grid;
-    grid-template-columns: auto 1fr;
+    grid-template-columns: auto minmax(0, 1fr);
     grid-template-rows: auto auto;
     grid-template-areas:
-      'brand nav'
-      'actions actions';
-    align-items: center;
+      'brand actions'
+      'nav nav';
+    align-items: flex-start;
     column-gap: 10px;
     row-gap: 12px;
   }
@@ -2320,20 +2330,16 @@ button {
   .site-header__brand {
     flex: 1 1 auto;
     grid-area: brand;
-    order: 0;
-    grid-column: 1;
-    grid-row: 1;
   }
 
   .site-header__nav {
     order: 0;
-    width: auto;
+    grid-area: nav;
+    width: 100%;
     margin: 0;
     justify-content: flex-start;
+    flex-wrap: wrap;
     gap: 16px;
-    grid-area: nav;
-    grid-column: 2;
-    grid-row: 1;
   }
 
   .site-header__link {
@@ -2345,15 +2351,13 @@ button {
     order: 0;
     margin-left: 0;
     flex: 0 1 auto;
-    width: auto;
+    width: 100%;
     gap: 8px;
     flex-wrap: wrap;
     justify-content: flex-end;
     grid-area: actions;
     justify-self: end;
     align-self: start;
-    grid-column: 1 / -1;
-    grid-row: 2;
   }
 
   .site-header__cta {
@@ -2393,43 +2397,41 @@ button {
 
 @media (max-width: 420px) {
   .site-header__row--main {
-    grid-template-columns: 1fr;
-    grid-template-rows: auto auto auto;
+    grid-template-columns: auto minmax(0, 1fr);
+    grid-template-rows: auto auto;
     grid-template-areas:
-      'brand'
-      'nav'
-      'actions';
-    row-gap: 14px;
+      'brand actions'
+      'nav nav';
+    column-gap: 8px;
+    row-gap: 12px;
   }
 
   .site-header__brand {
     justify-self: flex-start;
+    font-size: 0.82rem;
+    letter-spacing: 0.18em;
+    gap: 10px;
   }
 
   .site-header__nav {
     grid-area: nav;
-    grid-column: 1;
-    grid-row: 2;
     width: 100%;
     justify-content: flex-start;
-    align-items: stretch;
     flex-wrap: wrap;
-    gap: 12px;
+    gap: 10px;
   }
 
   .site-header__link {
-    flex: 1 1 100%;
-    text-align: left;
-    padding: 6px 4px;
+    flex: 0 1 auto;
+    padding: 6px 0;
   }
 
   .site-header__actions {
     grid-area: actions;
-    grid-column: 1;
-    grid-row: 3;
     width: 100%;
-    justify-content: flex-start;
-    gap: 10px;
+    justify-content: flex-end;
+    align-content: flex-start;
+    gap: 8px;
   }
 
   .site-header__cta {
@@ -2444,7 +2446,7 @@ button {
 
   .site-header__meta-group {
     order: 2;
-    flex: 1 1 auto;
+    flex: 1 1 100%;
     justify-content: flex-start;
   }
 }


### PR DESCRIPTION
## Summary
- realign the header grid at small breakpoints so the brand/actions share the top row and navigation spans the second row
- tweak spacing and sizing below 420px to keep controls wrapping inside two grid rows on compact iPhone SE style viewports

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cea281ce7c83318f6de00c493e65b8