### PR TITLE
Fix duplicate SeriesLogo type definition

### DIFF
--- a/lib/series.ts
+++ b/lib/series.ts
@@ -7,12 +7,6 @@ type SeriesLogo = {
   height: number;
 };
 
-type SeriesLogo = {
-  src: string;
-  width: number;
-  height: number;
-};
-
 type SeriesDefinitionBase = {
   label: string;
   accentColor: string;


### PR DESCRIPTION
## Summary
- remove the duplicate SeriesLogo type declaration that caused a TypeScript identifier conflict

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ceaeb021a88331a003965094c1f20a