### PR TITLE
Keep header controls on one line on mobile

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -2454,7 +2454,8 @@ button {
 
   .site-header__meta-group {
     order: 2;
-    flex: 1 1 100%;
+    flex: 0 1 auto;
     justify-content: flex-start;
+    min-width: 0;
   }
 }


### PR DESCRIPTION
## Summary
- prevent the header meta group from stretching to full width on narrow screens
- ensure the theme toggle and language selector stay on the same row on mobile devices

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cebdbd905c8331b01165f046875665