### PR TITLE
Remove event card series text pill

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -739,12 +739,6 @@ button {
   color: #0f162c;
 }
 
-:root[data-theme='light'] .event-card__series-pill {
-  background: rgba(var(--accent-rgb), 0.12);
-  border-color: rgba(var(--accent-rgb), 0.3);
-  color: rgba(var(--accent-rgb), 0.82);
-}
-
 :root[data-theme='light'] .event-card__datetime {
   color: rgba(18, 22, 37, 0.58);
 }
@@ -1699,7 +1693,6 @@ button {
 .control-panel__label,
 .series-chip,
 .period-button,
-.event-card__series-pill,
 .event-card__datetime,
 .event-card__time,
 .event-card__title,
@@ -2048,7 +2041,6 @@ button {
 .event-card__series {
   display: flex;
   align-items: center;
-  gap: 12px;
 }
 
 .event-card__series-logo {
@@ -2057,18 +2049,6 @@ button {
   width: auto;
   user-select: none;
   pointer-events: none;
-}
-
-.event-card__series-pill {
-  padding: 6px 14px;
-  border-radius: 999px;
-  border: 1px solid rgba(var(--accent-rgb), 0.45);
-  background: rgba(var(--accent-rgb), 0.22);
-  color: #ffffff;
-  font-size: 0.75rem;
-  font-weight: 700;
-  letter-spacing: 0.16em;
-  text-transform: uppercase;
 }
 
 .event-card__datetime {

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -625,7 +625,6 @@ export default function Home() {
                           aria-hidden="true"
                           draggable={false}
                         />
-                        <span className="event-card__series-pill">{definition.label}</span>
                       </div>
                       <time className="event-card__datetime" dateTime={isoLocal ?? undefined}>
                         <span className="event-card__time">{timeLabel}</span>

--- a/tests/site-layout.test.tsx
+++ b/tests/site-layout.test.tsx
@@ -100,7 +100,7 @@ describe('site layout rendering across languages', () => {
         });
 
         await waitFor(() => {
-          expect(document.querySelectorAll('.event-card__series-pill').length).toBeGreaterThan(0);
+          expect(document.querySelectorAll('.event-card__series-logo').length).toBeGreaterThan(0);
         });
       }
     } finally {


### PR DESCRIPTION
## Summary
- remove the series text pill from each event card so only the logo is shown
- clean up unused styles and adjust tests to match the streamlined markup

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cebe602c648331931c08875c010149