### PR TITLE
Adjust mobile header layout

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -2305,11 +2305,11 @@ button {
 
   .site-header__row--main {
     display: grid;
-    grid-template-columns: auto minmax(0, 1fr);
+    grid-template-columns: minmax(0, 1fr) auto;
     grid-template-rows: auto auto;
     grid-template-areas:
-      'brand actions'
-      'nav nav';
+      'brand brand'
+      'nav actions';
     align-items: flex-start;
     column-gap: 10px;
     row-gap: 12px;
@@ -2339,7 +2339,7 @@ button {
     order: 0;
     margin-left: 0;
     flex: 0 1 auto;
-    width: 100%;
+    width: auto;
     gap: 8px;
     flex-wrap: wrap;
     justify-content: flex-end;
@@ -2385,11 +2385,11 @@ button {
 
 @media (max-width: 420px) {
   .site-header__row--main {
-    grid-template-columns: auto minmax(0, 1fr);
+    grid-template-columns: minmax(0, 1fr) auto;
     grid-template-rows: auto auto;
     grid-template-areas:
-      'brand actions'
-      'nav nav';
+      'brand brand'
+      'nav actions';
     column-gap: 8px;
     row-gap: 12px;
   }
@@ -2416,7 +2416,7 @@ button {
 
   .site-header__actions {
     grid-area: actions;
-    width: 100%;
+    width: auto;
     justify-content: flex-end;
     align-content: flex-start;
     gap: 8px;


### PR DESCRIPTION
## Summary
- update the mobile header grid layout so that the navigation and actions share a single row
- allow the action group to size to its content instead of stretching full width on small screens

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ced36653b08331b1545af59a39e026