### PR TITLE
Keep event time inline on mobile

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -2283,6 +2283,26 @@ button {
   }
 }
 
+@media (max-width: 600px) {
+  .event-card__top {
+    flex-direction: row;
+    align-items: center;
+    gap: 12px;
+    flex-wrap: nowrap;
+  }
+
+  .event-card__datetime {
+    margin-left: auto;
+    align-items: flex-end;
+    gap: 2px;
+    letter-spacing: 0.08em;
+  }
+
+  .event-card__time {
+    letter-spacing: 0.1em;
+  }
+}
+
 @media (max-width: 720px) {
   .hero__layout {
     grid-template-columns: minmax(0, 1fr);


### PR DESCRIPTION
## Summary
- restore a horizontal layout for the event card header on very small viewports and prevent flex wrapping so the datetime stays beside the series logo
- tweak spacing for the datetime block to reduce its footprint on mobile widths

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ced3e7328c8331a9e68ae513c44f21