### PR TITLE
Align event card logo and time vertically

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -2032,7 +2032,7 @@ button {
 
 .event-card__top {
   display: flex;
-  align-items: flex-start;
+  align-items: center;
   justify-content: space-between;
   gap: 16px;
   flex-wrap: wrap;


### PR DESCRIPTION
## Summary
- center-align the contents of `.event-card__top` so the series logo and session time sit on the same vertical axis

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cf037be4848331baabfe3a3552988b