### PR TITLE
Adjust hero title and compact collapsed controls

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -2538,15 +2538,44 @@ button {
   .series-chips,
   .period-buttons {
     flex-direction: column;
-    gap: 10px;
+    gap: 8px;
   }
 
   .series-chip,
   .period-button {
     width: 100%;
     justify-content: space-between;
+    padding: 8px 12px;
+    letter-spacing: 0.06em;
+    font-size: 0.72rem;
+  }
+
+  .series-chip__indicator {
+    width: 8px;
+    height: 8px;
+    box-shadow: 0 0 0 3px rgba(var(--chip-rgb), 0.2);
+  }
+
+  .hero-card__summary {
+    gap: 12px;
+  }
+
+  .hero-card__summary-header {
+    gap: 8px;
+  }
+
+  .hero-card__summary-tags {
+    gap: 6px;
+  }
+
+  .hero-card__summary-body {
+    gap: 4px;
+  }
+
+  .hero-card__tag {
+    padding: 4px 10px;
+    font-size: 0.7rem;
     letter-spacing: 0.08em;
-    font-size: 0.78rem;
   }
 
   .events-section,

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -447,9 +447,7 @@ export default function Home() {
           }
         >
           <div className="hero__intro">
-            <h1 className="hero__title">
-              {texts.heroTitle(SERIES_TITLE || 'F1 / F2 / F3 / MotoGP')}
-            </h1>
+            <h1 className="hero__title">My coffee experience</h1>
             <p className="hero__subtitle">{texts.heroSubtitle}</p>
           </div>
         <div className="hero__layout">


### PR DESCRIPTION
## Summary
- replace the hero headline with the fixed "My coffee experience" title
- tighten spacing and sizing for filters and summary tags in the collapsed/mobile view

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d8f48dd69883318b605aab4e384d22