### PR TITLE
Fix hero title and tighten mobile filters

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1720,6 +1720,14 @@ button {
   min-width: 0;
 }
 
+.hero__column--controls {
+  align-items: flex-start;
+}
+
+.hero__column--summary {
+  align-items: stretch;
+}
+
 .hero-card {
   position: relative;
   z-index: 1;
@@ -2408,6 +2416,10 @@ button {
 }
 
 @media (max-width: 420px) {
+  .hero__column--controls .hero-card {
+    width: min(100%, 300px);
+  }
+
   .site-header__row--main {
     display: grid;
     grid-template-columns: minmax(0, 1fr) auto auto;
@@ -2535,18 +2547,56 @@ button {
     font-size: 0.95rem;
   }
 
+  .hero__column--controls {
+    align-items: center;
+  }
+
+  .hero__column--controls .hero-card {
+    width: min(100%, 340px);
+    margin: 0 auto;
+  }
+
   .series-chips,
   .period-buttons {
     flex-direction: column;
-    gap: 10px;
+    gap: 8px;
   }
 
   .series-chip,
   .period-button {
     width: 100%;
     justify-content: space-between;
+    padding: 8px 12px;
+    letter-spacing: 0.06em;
+    font-size: 0.72rem;
+  }
+
+  .series-chip__indicator {
+    width: 8px;
+    height: 8px;
+    box-shadow: 0 0 0 3px rgba(var(--chip-rgb), 0.2);
+  }
+
+  .hero-card__summary {
+    gap: 12px;
+  }
+
+  .hero-card__summary-header {
+    gap: 8px;
+  }
+
+  .hero-card__summary-tags {
+    gap: 6px;
+  }
+
+  .hero-card__summary-body {
+    gap: 4px;
+  }
+
+  .hero-card__tag {
+    padding: 4px 10px;
+    font-size: 0.7rem;
     letter-spacing: 0.08em;
-    font-size: 0.78rem;
   }
 
   .events-section,

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -22,8 +22,6 @@ import { buildCountdownLabel, filterEventsByVisibility, localizeEvent } from '..
 import { LANGUAGE_STORAGE_KEY, PERIOD_STORAGE_KEY, SERIES_STORAGE_KEY } from '../lib/preferences';
 import { useThemePreference } from './hooks/useThemePreference';
 
-const SERIES_TITLE = SERIES_IDS.map(series => SERIES_DEFINITIONS[series].label).join(' / ');
-
 export default function Home() {
   const { theme, toggleTheme } = useThemePreference();
   const [events, setEvents] = useState<ScheduleEvent[]>([]);
@@ -447,125 +445,123 @@ export default function Home() {
           }
         >
           <div className="hero__intro">
-            <h1 className="hero__title">
-              {texts.heroTitle(SERIES_TITLE || 'F1 / F2 / F3 / MotoGP')}
-            </h1>
+            <h1 className="hero__title">My coffee experience</h1>
             <p className="hero__subtitle">{texts.heroSubtitle}</p>
           </div>
-        <div className="hero__layout">
-          <div className="hero__column">
-            <div className="hero-card">
-              <div className="hero-card__section">
-                <div className="hero-card__section-header">
-                  <span className="control-panel__label">{texts.seriesLabel}</span>
-                  <span
-                    className="control-panel__selection"
-                    aria-live="polite"
-                    data-empty={!hasActiveSeries}
-                  >
-                    {activeSeriesSelection}
-                  </span>
-                </div>
-                <div className="series-chips">
-                  {SERIES_IDS.map(series => {
-                    const definition = SERIES_DEFINITIONS[series];
-                    return (
-                      <label
-                        key={series}
-                        className="series-chip"
-                        data-active={visibleSeries[series]}
-                        style={
-                          {
-                            '--chip-color': definition.accentColor,
-                            '--chip-rgb': definition.accentRgb,
-                          } as CSSProperties
-                        }
-                      >
-                        <input
-                          type="checkbox"
-                          checked={visibleSeries[series]}
-                          onChange={() =>
-                            setVisibleSeries(prev => ({
-                              ...prev,
-                              [series]: !prev[series],
-                            }))
-                          }
-                        />
-                        <span className="series-chip__indicator" aria-hidden />
-                        <span>{definition.label}</span>
-                      </label>
-                    );
-                  })}
-                </div>
-              </div>
-              <div className="hero-card__section">
-                <div className="hero-card__section-header">
-                  <span className="control-panel__label">{texts.reviewPeriodLabel}</span>
-                </div>
-                <div className="period-buttons">
-                  {periodOptions.map(opt => (
-                    <button
-                      key={opt.label}
-                      type="button"
-                      className="period-button"
-                      data-active={hours === opt.value}
-                      onClick={() => setHours(opt.value)}
+          <div className="hero__layout">
+            <div className="hero__column hero__column--controls">
+              <div className="hero-card">
+                <div className="hero-card__section">
+                  <div className="hero-card__section-header">
+                    <span className="control-panel__label">{texts.seriesLabel}</span>
+                    <span
+                      className="control-panel__selection"
+                      aria-live="polite"
+                      data-empty={!hasActiveSeries}
                     >
-                      {opt.label}
-                    </button>
-                  ))}
+                      {activeSeriesSelection}
+                    </span>
+                  </div>
+                  <div className="series-chips">
+                    {SERIES_IDS.map(series => {
+                      const definition = SERIES_DEFINITIONS[series];
+                      return (
+                        <label
+                          key={series}
+                          className="series-chip"
+                          data-active={visibleSeries[series]}
+                          style={
+                            {
+                              '--chip-color': definition.accentColor,
+                              '--chip-rgb': definition.accentRgb,
+                            } as CSSProperties
+                          }
+                        >
+                          <input
+                            type="checkbox"
+                            checked={visibleSeries[series]}
+                            onChange={() =>
+                              setVisibleSeries(prev => ({
+                                ...prev,
+                                [series]: !prev[series],
+                              }))
+                            }
+                          />
+                          <span className="series-chip__indicator" aria-hidden />
+                          <span>{definition.label}</span>
+                        </label>
+                      );
+                    })}
+                  </div>
                 </div>
-                <div className="hero__event-summary">
-                  <span className="hero__event-summary-label">{texts.eventsInWindowLabel}</span>
-                  <span className="hero__event-summary-value">{filtered.length}</span>
-                  <span className="hero__event-summary-period">{selectedPeriodLabel}</span>
+                <div className="hero-card__section">
+                  <div className="hero-card__section-header">
+                    <span className="control-panel__label">{texts.reviewPeriodLabel}</span>
+                  </div>
+                  <div className="period-buttons">
+                    {periodOptions.map(opt => (
+                      <button
+                        key={opt.label}
+                        type="button"
+                        className="period-button"
+                        data-active={hours === opt.value}
+                        onClick={() => setHours(opt.value)}
+                      >
+                        {opt.label}
+                      </button>
+                    ))}
+                  </div>
+                  <div className="hero__event-summary">
+                    <span className="hero__event-summary-label">{texts.eventsInWindowLabel}</span>
+                    <span className="hero__event-summary-value">{filtered.length}</span>
+                    <span className="hero__event-summary-period">{selectedPeriodLabel}</span>
+                  </div>
                 </div>
               </div>
             </div>
-          </div>
-          <div className="hero__column">
-            <div className="hero-card hero-card--summary">
-              <span className="hero-card__label">{texts.nextStartLabel}</span>
-              {nextEvent && nextLocal ? (
-                <div className="hero-card__summary">
-                  <div className="hero-card__summary-header">
-                    <span className="hero-card__value">{nextLocal.toFormat('dd LLL • HH:mm')}</span>
-                    {nextSeriesLabel || nextSessionLabel ? (
-                      <div className="hero-card__summary-tags">
-                        {nextSeriesLabel ? (
-                          <span className="hero-card__tag hero-card__tag--accent">{nextSeriesLabel}</span>
-                        ) : null}
-                        {nextSessionLabel ? (
-                          <span className="hero-card__tag hero-card__tag--muted">{nextSessionLabel}</span>
-                        ) : null}
+            <div className="hero__column hero__column--summary">
+              <div className="hero-card hero-card--summary">
+                <span className="hero-card__label">{texts.nextStartLabel}</span>
+                {nextEvent && nextLocal ? (
+                  <div className="hero-card__summary">
+                    <div className="hero-card__summary-header">
+                      <span className="hero-card__value">{nextLocal.toFormat('dd LLL • HH:mm')}</span>
+                      {nextSeriesLabel || nextSessionLabel ? (
+                        <div className="hero-card__summary-tags">
+                          {nextSeriesLabel ? (
+                            <span className="hero-card__tag hero-card__tag--accent">{nextSeriesLabel}</span>
+                          ) : null}
+                          {nextSessionLabel ? (
+                            <span className="hero-card__tag hero-card__tag--muted">{nextSessionLabel}</span>
+                          ) : null}
+                        </div>
+                      ) : null}
+                    </div>
+                    <div className="hero-card__summary-body">
+                      <span className="hero-card__meta hero-card__meta--title">{nextEvent.round}</span>
+                      {nextDetailsLabel ? (
+                        <span className="hero-card__meta hero-card__meta--muted">
+                          {nextDetailsLabel}
+                        </span>
+                      ) : null}
+                    </div>
+                    {nextCountdown ? (
+                      <div className={nextCountdownClassName} aria-live={nextStatus === 'live' ? 'polite' : 'off'}>
+                        <span className="event-card__countdown-dot" aria-hidden />
+                        <span>{nextCountdown}</span>
                       </div>
                     ) : null}
                   </div>
-                  <div className="hero-card__summary-body">
-                    <span className="hero-card__meta hero-card__meta--title">{nextEvent.round}</span>
-                    {nextDetailsLabel ? (
-                      <span className="hero-card__meta hero-card__meta--muted">
-                        {nextDetailsLabel}
-                      </span>
-                    ) : null}
-                  </div>
-                  {nextCountdown ? (
-                    <div className={nextCountdownClassName} aria-live={nextStatus === 'live' ? 'polite' : 'off'}>
-                      <span className="event-card__countdown-dot" aria-hidden />
-                      <span>{nextCountdown}</span>
-                    </div>
-                  ) : null}
-                </div>
-              ) : (
-                <>
-                  <span className="hero-card__value">{texts.noEvents}</span>
-                  <span className="hero-card__meta hero-card__meta--muted">
-                    {texts.extendPeriodHint}
-                  </span>
-                </>
-              )}
+                ) : (
+                  <>
+                    <span className="hero-card__value">{texts.noEvents}</span>
+                    <span className="hero-card__meta hero-card__meta--muted">
+                      {texts.extendPeriodHint}
+                    </span>
+                  </>
+                )}
+              </div>
             </div>
-          </div>
           </div>
         </section>
         <section className="events-section" aria-labelledby="schedule-heading">

--- a/lib/language.ts
+++ b/lib/language.ts
@@ -145,8 +145,7 @@ export const LANGUAGE_DEFINITIONS: Record<LanguageCode, LanguageDefinition> = {
     },
     texts: {
       heroBadge: 'живой календарь уик-эндов',
-      heroTitle: seriesTitle =>
-        `Ближайшие квалификации и гонки — ${seriesTitle || 'F1 / F2 / F3 / MotoGP'}`,
+      heroTitle: () => 'My coffee experience',
       heroSubtitle:
         'Синхронизируйтесь с динамикой гоночных уик-эндов: фильтруйте серии, управляйте горизонтом просмотра и следите за временем старта в собственном часовом поясе.',
       seriesLabel: 'Серии',
@@ -324,8 +323,7 @@ export const LANGUAGE_DEFINITIONS: Record<LanguageCode, LanguageDefinition> = {
     },
     texts: {
       heroBadge: 'live weekend calendar',
-      heroTitle: seriesTitle =>
-        `Upcoming qualifying & races — ${seriesTitle || 'F1 / F2 / F3 / MotoGP'}`,
+      heroTitle: () => 'My coffee experience',
       heroSubtitle:
         'Stay in sync with race weekends: filter the series, adjust the viewing window, and track session times in your own timezone.',
       seriesLabel: 'Series',
@@ -503,8 +501,7 @@ export const LANGUAGE_DEFINITIONS: Record<LanguageCode, LanguageDefinition> = {
     },
     texts: {
       heroBadge: 'calendario de fines de semana en vivo',
-      heroTitle: seriesTitle =>
-        `Próximas clasificaciones y carreras — ${seriesTitle || 'F1 / F2 / F3 / MotoGP'}`,
+      heroTitle: () => 'My coffee experience',
       heroSubtitle:
         'Mantente sincronizado con los fines de semana de carreras: filtra las series, ajusta la ventana de visualización y sigue los horarios de las sesiones en tu propio huso horario.',
       seriesLabel: 'Series',
@@ -682,8 +679,7 @@ export const LANGUAGE_DEFINITIONS: Record<LanguageCode, LanguageDefinition> = {
     },
     texts: {
       heroBadge: 'calendrier des week-ends en direct',
-      heroTitle: seriesTitle =>
-        `Prochaines qualifications et courses — ${seriesTitle || 'F1 / F2 / F3 / MotoGP'}`,
+      heroTitle: () => 'My coffee experience',
       heroSubtitle:
         'Restez synchronisé avec les week-ends de course : filtrez les séries, ajustez la fenêtre d’affichage et suivez les horaires des sessions dans votre propre fuseau horaire.',
       seriesLabel: 'Séries',
@@ -861,8 +857,7 @@ export const LANGUAGE_DEFINITIONS: Record<LanguageCode, LanguageDefinition> = {
     },
     texts: {
       heroBadge: 'Live-Wochenendkalender',
-      heroTitle: seriesTitle =>
-        `Bevorstehende Qualifyings & Rennen — ${seriesTitle || 'F1 / F2 / F3 / MotoGP'}`,
+      heroTitle: () => 'My coffee experience',
       heroSubtitle:
         'Bleib mit den Rennwochenenden im Takt: Filtere die Serien, passe das Betrachtungsfenster an und verfolge die Sessionzeiten in deiner eigenen Zeitzone.',
       seriesLabel: 'Serien',
@@ -1040,8 +1035,7 @@ export const LANGUAGE_DEFINITIONS: Record<LanguageCode, LanguageDefinition> = {
     },
     texts: {
       heroBadge: '周末赛事实时日历',
-      heroTitle: seriesTitle =>
-        `即将到来的排位赛与正赛 — ${seriesTitle || 'F1 / F2 / F3 / MotoGP'}`,
+      heroTitle: () => 'My coffee experience',
       heroSubtitle:
         '掌握赛周节奏：筛选系列、调整查看窗口，并在本地时区追踪各场次开始时间。',
       seriesLabel: '系列',

--- a/tests/localization.test.ts
+++ b/tests/localization.test.ts
@@ -41,7 +41,7 @@ describe('localization configuration', () => {
         const { texts } = definition;
         expect(texts.heroBadge.trim().length).toBeGreaterThan(0);
         const sampleTitle = texts.heroTitle('F1 / F2');
-        expect(sampleTitle).toMatch(/F1/);
+        expect(sampleTitle).toBe('My coffee experience');
         expect(texts.heroSubtitle.trim().length).toBeGreaterThan(0);
         expect(texts.seriesLabel.trim().length).toBeGreaterThan(0);
         expect(texts.activeSelection(['F1']).trim().length).toBeGreaterThan(0);


### PR DESCRIPTION
## Summary
- enforce the static "My coffee experience" hero title across all languages
- narrow the mobile filter column on small screens so the controls no longer cover the globe

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d8f48dd69883318b605aab4e384d22