### PR TITLE
Добавить состояния загрузки и ошибки при загрузке расписания

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -836,6 +836,30 @@ button {
   box-shadow: 0 0 0 6px rgba(18, 24, 35, 0.12);
 }
 
+:root[data-theme='light'] .schedule-error {
+  border-color: rgba(193, 45, 45, 0.3);
+  background: rgba(255, 238, 238, 0.9);
+}
+
+:root[data-theme='light'] .schedule-error__title {
+  color: #6b1f1f;
+}
+
+:root[data-theme='light'] .schedule-error__description,
+:root[data-theme='light'] .schedule-error__fallback {
+  color: rgba(18, 22, 37, 0.72);
+}
+
+:root[data-theme='light'] .schedule-error__retry {
+  border-color: rgba(193, 45, 45, 0.34);
+  background: rgba(193, 45, 45, 0.12);
+  color: #6b1f1f;
+}
+
+:root[data-theme='light'] .schedule-error__retry:hover {
+  background: rgba(193, 45, 45, 0.2);
+}
+
 :root[data-theme='light'] .cta-section__content p {
   color: rgba(18, 22, 37, 0.7);
 }
@@ -1995,6 +2019,74 @@ button {
   display: grid;
   gap: clamp(20px, 5vw, 32px);
   grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.schedule-error {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  border-radius: 18px;
+  padding: 16px 18px;
+  border: 1px solid rgba(255, 104, 104, 0.36);
+  background: rgba(85, 22, 22, 0.32);
+}
+
+.schedule-error__content {
+  display: grid;
+  gap: 6px;
+}
+
+.schedule-error__title {
+  font-weight: 700;
+  color: rgba(255, 206, 206, 0.96);
+}
+
+.schedule-error__description,
+.schedule-error__fallback {
+  color: rgba(255, 255, 255, 0.8);
+  font-size: 0.92rem;
+}
+
+.schedule-error__fallback a {
+  color: inherit;
+  text-decoration: underline;
+  text-underline-offset: 3px;
+}
+
+.schedule-error__retry {
+  border: 1px solid rgba(255, 173, 173, 0.5);
+  border-radius: 12px;
+  padding: 10px 14px;
+  font-weight: 700;
+  cursor: pointer;
+  background: rgba(255, 173, 173, 0.16);
+  color: rgba(255, 221, 221, 0.96);
+}
+
+.event-card--skeleton {
+  pointer-events: none;
+}
+
+.event-card--skeleton .event-card__inner {
+  min-height: clamp(220px, 44vw, 300px);
+  position: relative;
+  overflow: hidden;
+}
+
+.event-card--skeleton .event-card__inner::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(100deg, rgba(255, 255, 255, 0.05) 20%, rgba(255, 255, 255, 0.16) 50%, rgba(255, 255, 255, 0.05) 80%);
+  transform: translateX(-100%);
+  animation: skeleton-loading 1.2s ease-in-out infinite;
+}
+
+@keyframes skeleton-loading {
+  to {
+    transform: translateX(100%);
+  }
 }
 
 .event-card {

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -22,9 +22,14 @@ import { buildCountdownLabel, filterEventsByVisibility, localizeEvent } from '..
 import { LANGUAGE_STORAGE_KEY, PERIOD_STORAGE_KEY, SERIES_STORAGE_KEY } from '../lib/preferences';
 import { useThemePreference } from './hooks/useThemePreference';
 
+const SCHEDULE_URL = './schedule.ics';
+
 export default function Home() {
   const { theme, toggleTheme } = useThemePreference();
   const [events, setEvents] = useState<ScheduleEvent[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [isError, setIsError] = useState(false);
+  const [errorMessage, setErrorMessage] = useState('');
   const [visibleSeries, setVisibleSeries] = useState<Record<SeriesId, boolean>>(() =>
     buildSeriesVisibility(true),
   );
@@ -38,15 +43,33 @@ export default function Home() {
   const headerRef = useRef<HTMLElement | null>(null);
   const languageControlRef = useRef<HTMLDivElement | null>(null);
   const privacyPolicyDialogRef = useRef<HTMLDivElement | null>(null);
-  useEffect(() => {
-    async function load() {
-      const text = await fetch('./schedule.ics').then(r => r.text());
+
+  const loadSchedule = useCallback(async () => {
+    setIsLoading(true);
+    setIsError(false);
+    setErrorMessage('');
+
+    try {
+      const response = await fetch(SCHEDULE_URL);
+      if (!response.ok) {
+        throw new Error(`HTTP ${response.status}`);
+      }
+      const text = await response.text();
       const parsed = parseSchedule(text);
       setEvents(parsed);
+    } catch (error) {
+      setEvents([]);
+      setIsError(true);
+      setErrorMessage(error instanceof Error ? error.message : String(error));
+    } finally {
+      setIsLoading(false);
     }
-    load().catch(console.error);
-    setUserTz(DateTime.local().zoneName);
   }, []);
+
+  useEffect(() => {
+    loadSchedule().catch(console.error);
+    setUserTz(DateTime.local().zoneName);
+  }, [loadSchedule]);
 
   useEffect(() => {
     if (typeof localStorage === 'undefined') {
@@ -572,8 +595,36 @@ export default function Home() {
             </h2>
             <p className="section-heading__description">{texts.scheduleSubtitle}</p>
           </div>
+          {isError ? (
+            <div className="schedule-error" role="alert">
+              <div className="schedule-error__content">
+                <p className="schedule-error__title">{texts.scheduleErrorTitle}</p>
+                <p className="schedule-error__description">{texts.scheduleErrorDescription}</p>
+                <p className="schedule-error__fallback">
+                  {texts.scheduleErrorFallbackPrefix}{' '}
+                  <a href={SCHEDULE_URL} target="_blank" rel="noreferrer noopener">
+                    {texts.scheduleIcsLinkLabel}
+                  </a>
+                  {errorMessage ? ` (${errorMessage})` : null}
+                </p>
+              </div>
+              <button type="button" className="schedule-error__retry" onClick={() => void loadSchedule()}>
+                {texts.scheduleRetryButton}
+              </button>
+            </div>
+          ) : null}
           <ul className="events-grid">
-            {localizedEvents.map((localized, index) => {
+            {isLoading
+              ? Array.from({ length: 6 }).map((_, index) => (
+                  <li
+                    key={`event-skeleton-${index}`}
+                    className="event-card event-card--skeleton"
+                    aria-label={texts.scheduleLoadingLabel}
+                  >
+                    <div className="event-card__inner" />
+                  </li>
+                ))
+              : localizedEvents.map((localized, index) => {
               const { event, localStart, status, startRelative, finishRelative } = localized;
               const definition = SERIES_DEFINITIONS[event.series];
               const accentColor = definition.accentColor;

--- a/lib/language.ts
+++ b/lib/language.ts
@@ -91,6 +91,12 @@ type TranslationBundle = {
   heroCta: string;
   scheduleTitle: string;
   scheduleSubtitle: string;
+  scheduleLoadingLabel: string;
+  scheduleErrorTitle: string;
+  scheduleErrorDescription: string;
+  scheduleRetryButton: string;
+  scheduleErrorFallbackPrefix: string;
+  scheduleIcsLinkLabel: string;
   featuresTitle: string;
   featuresSubtitle: string;
   features: FeatureDescriptor[];
@@ -182,6 +188,12 @@ export const LANGUAGE_DEFINITIONS: Record<LanguageCode, LanguageDefinition> = {
       heroCta: 'К событиям',
       scheduleTitle: 'Лента уик-эндов',
       scheduleSubtitle: 'Онлайн-обновление стартов с учётом вашего часового пояса.',
+      scheduleLoadingLabel: 'Загружаем расписание…',
+      scheduleErrorTitle: 'Не удалось загрузить расписание',
+      scheduleErrorDescription: 'Попробуйте ещё раз. Если ошибка повторится, откройте файл расписания вручную.',
+      scheduleRetryButton: 'Повторить',
+      scheduleErrorFallbackPrefix: 'Файл для диагностики:',
+      scheduleIcsLinkLabel: 'Открыть schedule.ics',
       featuresTitle: 'Сила оперативного календаря',
       featuresSubtitle: 'Всё, чтобы не пропустить старт.',
       features: [
@@ -360,6 +372,12 @@ export const LANGUAGE_DEFINITIONS: Record<LanguageCode, LanguageDefinition> = {
       heroCta: 'Browse schedule',
       scheduleTitle: 'Weekend feed',
       scheduleSubtitle: 'Live-updated start times aligned with your timezone.',
+      scheduleLoadingLabel: 'Loading schedule…',
+      scheduleErrorTitle: 'Could not load the schedule',
+      scheduleErrorDescription: 'Please try again. If this keeps happening, open the schedule file directly.',
+      scheduleRetryButton: 'Retry',
+      scheduleErrorFallbackPrefix: 'Diagnostic file:',
+      scheduleIcsLinkLabel: 'Open schedule.ics',
       featuresTitle: 'Why fans choose RaceSync',
       featuresSubtitle: 'Purpose-built utilities for race weekend planning.',
       features: [
@@ -538,6 +556,12 @@ export const LANGUAGE_DEFINITIONS: Record<LanguageCode, LanguageDefinition> = {
       heroCta: 'Ver calendario',
       scheduleTitle: 'Flujo de fines de semana',
       scheduleSubtitle: 'Horarios actualizados en vivo según tu zona horaria.',
+      scheduleLoadingLabel: 'Cargando calendario…',
+      scheduleErrorTitle: 'No se pudo cargar el calendario',
+      scheduleErrorDescription: 'Inténtalo de nuevo. Si el problema continúa, abre el archivo del calendario directamente.',
+      scheduleRetryButton: 'Reintentar',
+      scheduleErrorFallbackPrefix: 'Archivo para diagnóstico:',
+      scheduleIcsLinkLabel: 'Abrir schedule.ics',
       featuresTitle: 'Por qué elegir RaceSync',
       featuresSubtitle: 'Herramientas creadas para planificar cada sesión.',
       features: [
@@ -716,6 +740,12 @@ export const LANGUAGE_DEFINITIONS: Record<LanguageCode, LanguageDefinition> = {
       heroCta: 'Consulter le calendrier',
       scheduleTitle: 'Flux des week-ends',
       scheduleSubtitle: 'Heures de départ mises à jour en direct dans votre fuseau horaire.',
+      scheduleLoadingLabel: 'Chargement du calendrier…',
+      scheduleErrorTitle: 'Impossible de charger le calendrier',
+      scheduleErrorDescription: 'Réessayez. Si le problème persiste, ouvrez le fichier du calendrier directement.',
+      scheduleRetryButton: 'Réessayer',
+      scheduleErrorFallbackPrefix: 'Fichier de diagnostic :',
+      scheduleIcsLinkLabel: 'Ouvrir schedule.ics',
       featuresTitle: 'Pourquoi choisir RaceSync',
       featuresSubtitle: 'Des outils pensés pour organiser chaque session.',
       features: [
@@ -894,6 +924,12 @@ export const LANGUAGE_DEFINITIONS: Record<LanguageCode, LanguageDefinition> = {
       heroCta: 'Zum Kalender',
       scheduleTitle: 'Wochenend-Feed',
       scheduleSubtitle: 'Live aktualisierte Startzeiten in deiner Zeitzone.',
+      scheduleLoadingLabel: 'Zeitplan wird geladen…',
+      scheduleErrorTitle: 'Zeitplan konnte nicht geladen werden',
+      scheduleErrorDescription: 'Bitte versuche es erneut. Wenn der Fehler bleibt, öffne die Kalenderdatei direkt.',
+      scheduleRetryButton: 'Erneut versuchen',
+      scheduleErrorFallbackPrefix: 'Diagnosedatei:',
+      scheduleIcsLinkLabel: 'schedule.ics öffnen',
       featuresTitle: 'Darum RaceSync',
       featuresSubtitle: 'Durchdachte Werkzeuge für deine Rennplanung.',
       features: [
@@ -1072,6 +1108,12 @@ export const LANGUAGE_DEFINITIONS: Record<LanguageCode, LanguageDefinition> = {
       heroCta: '查看赛程',
       scheduleTitle: '周末赛程流',
       scheduleSubtitle: '开赛时间实时更新并匹配你的时区。',
+      scheduleLoadingLabel: '正在加载赛程…',
+      scheduleErrorTitle: '无法加载赛程',
+      scheduleErrorDescription: '请重试。如果问题持续，请直接打开赛程文件。',
+      scheduleRetryButton: '重试',
+      scheduleErrorFallbackPrefix: '诊断文件：',
+      scheduleIcsLinkLabel: '打开 schedule.ics',
       featuresTitle: '为什么选择 RaceSync',
       featuresSubtitle: '为赛车周末而生的实用功能。',
       features: [


### PR DESCRIPTION
### Motivation
- Избежать «пустого экрана» при неуспешном `fetch('./schedule.ics')` и дать пользователю явную обратную связь при ошибках или во время загрузки. 

### Description
- В `app/page.tsx` добавлены состояния `isLoading`, `isError`, `errorMessage` и вынесена логика загрузки в `loadSchedule` (с проверкой `response.ok` и обработкой исключений). 
- Во время загрузки показываются скелетон-карточки (`event-card--skeleton`), а при ошибке отображается локализованная плашка ошибки с описанием, кнопкой «Повторить» и ссылкой на `schedule.ics`. 
- Обновлён `lib/language.ts` — расширены `TranslationBundle` и все языковые наборы (RU/EN/ES/FR/DE/ZH) новыми строками для загрузки/ошибки/повтора/файла диагностики. 
- Добавлены стили для ошибки и эффекта skeleton shimmer в `app/globals.css`. 

### Testing
- Запущены юнит/интеграционные тесты через `npm test`, все тесты прошли (29/29). 
- `npm run build` не прошёл в этой среде из-за невозможности скачать Google Fonts (`Exo 2`, `Manrope`) с `fonts.googleapis.com`, что является сетевой проблемой окружения и не связано с логикой изменений.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c407b4e250833186393d200501e958)