### PR TITLE
Fix CI: @types/node peer range, Node 22 runners, drop shebang

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: CI
+﻿name: CI
 
 on:
   push:
@@ -18,7 +18,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: npm
 
       - name: Install

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,4 +1,4 @@
-name: Deploy Next.js to GitHub Pages
+﻿name: Deploy Next.js to GitHub Pages
 on:
   push:
     branches: [ main ]
@@ -23,7 +23,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: npm
 
       - name: Install

--- a/.github/workflows/update-schedule.yml
+++ b/.github/workflows/update-schedule.yml
@@ -1,4 +1,4 @@
-name: Update schedule
+﻿name: Update schedule
 
 on:
   schedule:
@@ -24,7 +24,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: npm
 
       - name: Install

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
       "devDependencies": {
         "@testing-library/react": "14.3.1",
         "@types/luxon": "^3.4.2",
-        "@types/node": "22.5.4",
+        "@types/node": "^22.12.0",
         "@types/react": "18.3.3",
         "jsdom": "^27.0.0",
         "typescript": "5.6.2",
@@ -1333,13 +1333,13 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "22.5.4",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.5.4.tgz",
-      "integrity": "sha512-FDuKUJQm/ju9fT/SeX/6+gBzoPzlVCzfzmGkwKvRHQVxi4BntVbyIwf6a4Xn62mrvndLiml6z/UBXIdEVjQLXg==",
+      "version": "22.20.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.1.tgz",
+      "integrity": "sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.19.2"
+        "undici-types": "~6.21.0"
       }
     },
     "node_modules/@types/prop-types": {
@@ -3457,9 +3457,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "6.19.8",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
-      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "devDependencies": {
     "@testing-library/react": "14.3.1",
     "@types/luxon": "^3.4.2",
-    "@types/node": "22.5.4",
+    "@types/node": "^22.12.0",
     "@types/react": "18.3.3",
     "jsdom": "^27.0.0",
     "typescript": "5.6.2",

--- a/scripts/update-schedule.mjs
+++ b/scripts/update-schedule.mjs
@@ -1,4 +1,3 @@
-#!/usr/bin/env node
 /**
  * Regenerates public/schedule.ics from the sportstimes/f1 open-data calendars
  * (MIT-licensed, https://github.com/sportstimes/f1 — the data behind f1calendar.com).


### PR DESCRIPTION
CI падал на \
pm ci\: vite 7 требует optional peer \@types/node ^20.19 || >=22.12\, а в корне был запинен \22.5.4\ — npm 10 на Node 20 пытался докинуть свежий \@types/node\, которого нет в lock-файле.

- \@types/node\ → \^22.12.0\
- CI-раннеры переведены на Node 22 (совпадает с локальной разработкой)
- убран шебанг из \scripts/update-schedule.mjs\ — vitest оборачивает модуль в loader, и шебанг перестаёт быть на первой строке (native ESM такое отвергает)

Проверено: \
pm ci --dry-run\ ✓ · tsc ✓ · 40/40 тестов ✓ · build ✓