### PR TITLE
Fix mixed-language hero: translate heroTitle per language

### DIFF
--- a/lib/language/de.ts
+++ b/lib/language/de.ts
@@ -19,7 +19,7 @@ export const de: LanguageDefinition = {
     Sprint: 'Sprint',
   },
   texts: {
-    heroTitle: 'My race weekend',
+    heroTitle: 'Mein Rennwochenende',
     heroSubtitle:
       'Bleib mit den Rennwochenenden im Takt: Filtere die Serien, passe das Betrachtungsfenster an und verfolge die Sessionzeiten in deiner eigenen Zeitzone.',
     seriesLabel: 'Serien',

--- a/lib/language/es.ts
+++ b/lib/language/es.ts
@@ -19,7 +19,7 @@ export const es: LanguageDefinition = {
     Sprint: 'Sprint',
   },
   texts: {
-    heroTitle: 'My race weekend',
+    heroTitle: 'Mi fin de semana de carreras',
     heroSubtitle:
       'Mantente sincronizado con los fines de semana de carreras: filtra las series, ajusta la ventana de visualización y sigue los horarios de las sesiones en tu propio huso horario.',
     seriesLabel: 'Series',

--- a/lib/language/fr.ts
+++ b/lib/language/fr.ts
@@ -19,7 +19,7 @@ export const fr: LanguageDefinition = {
     Sprint: 'Sprint',
   },
   texts: {
-    heroTitle: 'My race weekend',
+    heroTitle: 'Mon week-end de course',
     heroSubtitle:
       'Restez synchronisé avec les week-ends de course : filtrez les séries, ajustez la fenêtre d’affichage et suivez les horaires des sessions dans votre propre fuseau horaire.',
     seriesLabel: 'Séries',

--- a/lib/language/ru.ts
+++ b/lib/language/ru.ts
@@ -19,7 +19,7 @@ export const ru: LanguageDefinition = {
     Sprint: 'Спринт',
   },
   texts: {
-    heroTitle: 'My race weekend',
+    heroTitle: 'Мой гоночный уик-энд',
     heroSubtitle:
       'Синхронизируйтесь с динамикой гоночных уик-эндов: фильтруйте серии, управляйте горизонтом просмотра и следите за временем старта в собственном часовом поясе.',
     seriesLabel: 'Серии',

--- a/lib/language/zh.ts
+++ b/lib/language/zh.ts
@@ -18,7 +18,7 @@ export const zh: LanguageDefinition = {
     Sprint: '冲刺赛',
   },
   texts: {
-    heroTitle: 'My race weekend',
+    heroTitle: '我的赛车周末',
     heroSubtitle: '掌握赛周节奏：筛选系列、调整查看窗口，并在本地时区追踪各场次开始时间。',
     seriesLabel: '系列',
     activeSelection: names => `已选择：${names.join(' · ')}`,

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,7 +1,7 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import './.next/types/routes.d.ts';
-import './.next/types/root-params.d.ts';
+import "./.next/types/routes.d.ts";
+import "./.next/types/root-params.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.


### PR DESCRIPTION
Заголовок героя был одной английской строкой \My race weekend\ во всех языковых бандлах — дефект исходной реализации (функция i18n игнорировала аргумент и возвращала константу). Теперь у каждого языка настоящий перевод:

- ru: «Мой гоночный уик-энд»
- es: Mi fin de semana de carreras
- fr: Mon week-end de course
- de: Mein Rennwochenende
- zh: 我的赛车周末

Проверки: format ✓ · tsc ✓ · 40/40 ✓ · build ✓